### PR TITLE
Add clients list page

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,5 @@
 VITE_OIDC_AUTHORITY=http://localhost:8080
 VITE_OIDC_CLIENT_ID=admin
+VITE_OIDC_SCOPE=openid admin:clients:read admin:users:read admin:users:write admin:users:delete admin:access:read admin:access:write admin:sessions:read admin:sessions:write
 VITE_OIDC_REDIRECT_URI=http://localhost:5174/callback
 VITE_OIDC_POST_LOGOUT_REDIRECT_URI=http://localhost:5174

--- a/src/client/AbstractApi.ts
+++ b/src/client/AbstractApi.ts
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/stores/useAuthStore'
 
 export interface QueryOptions {
   path: string
+  params?: Record<string, string>
   timeoutInMs?: number
 }
 
@@ -66,6 +67,11 @@ export class AbstractApi {
   private getUrl(options: QueryOptions): string {
     const url = new URL(`${document.location.protocol}//${document.location.host}`)
     url.pathname = options.path
+    if (options.params) {
+      for (const [key, value] of Object.entries(options.params)) {
+        url.searchParams.set(key, value)
+      }
+    }
     return url.toString()
   }
 

--- a/src/client/api/ClientApi.ts
+++ b/src/client/api/ClientApi.ts
@@ -1,0 +1,23 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type ClientListResource,
+  clientListResourceSchema,
+} from '@/client/model/ClientListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export class ClientApi extends AbstractApi {
+  async listClients(
+    page: number = 0,
+    size: number = 20,
+  ): Promise<SuccessApiResponse<ClientListResource> | ErrorApiResponse> {
+    return this.get<ClientListResource>({
+      path: '/api/v1/admin/clients',
+      params: {
+        page: page.toString(),
+        size: size.toString(),
+      },
+      schema: clientListResourceSchema,
+    })
+  }
+}

--- a/src/client/model/ClientListResource.ts
+++ b/src/client/model/ClientListResource.ts
@@ -1,0 +1,30 @@
+import type { JSONSchemaType } from 'ajv'
+import { type ClientResource, clientResourceSchema } from '@/client/model/ClientResource'
+
+export type ClientListResource = {
+  clients: ClientResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const clientListResourceSchema: JSONSchemaType<ClientListResource> = {
+  type: 'object',
+  properties: {
+    clients: {
+      type: 'array',
+      items: { ...clientResourceSchema },
+    },
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    total: {
+      type: 'number',
+    },
+  },
+  required: ['clients', 'page', 'size', 'total'],
+  additionalProperties: true,
+}

--- a/src/client/model/ClientResource.ts
+++ b/src/client/model/ClientResource.ts
@@ -1,0 +1,32 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type ClientResource = {
+  client_id: string
+  allowed_scopes: string[]
+  default_scopes: string[]
+  allowed_redirect_uris?: string[]
+}
+
+export const clientResourceSchema: JSONSchemaType<ClientResource> = {
+  type: 'object',
+  properties: {
+    client_id: {
+      type: 'string',
+    },
+    allowed_scopes: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    default_scopes: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+    allowed_redirect_uris: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+  },
+  required: ['client_id', 'allowed_scopes', 'default_scopes'],
+  additionalProperties: true,
+}

--- a/src/components/PaginatedTable.vue
+++ b/src/components/PaginatedTable.vue
@@ -60,7 +60,7 @@ function nextPage() {
   <!-- Table -->
   <div v-else>
     <div class="overflow-x-auto">
-      <table class="min-w-full divide-y divide-gray-200">
+      <table class="w-full table-fixed divide-y divide-gray-200">
         <thead class="bg-gray-50">
           <tr>
             <slot name="header" />

--- a/src/components/PaginatedTable.vue
+++ b/src/components/PaginatedTable.vue
@@ -1,0 +1,100 @@
+<script lang="ts" setup>
+import { useI18n } from 'vue-i18n'
+import CommonSpinner from '@/components/CommonSpinner.vue'
+import CommonAlert from '@/components/CommonAlert.vue'
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/outline'
+
+const { t } = useI18n()
+
+const props = withDefaults(
+  defineProps<{
+    loading?: boolean
+    error?: string | null
+    empty?: boolean
+    page?: number
+    totalPages?: number
+  }>(),
+  {
+    loading: false,
+    error: null,
+    empty: false,
+    page: 0,
+    totalPages: 1,
+  },
+)
+
+const emit = defineEmits<{
+  pageChange: [page: number]
+}>()
+
+function previousPage() {
+  if (props.page > 0) {
+    emit('pageChange', props.page - 1)
+  }
+}
+
+function nextPage() {
+  if (props.page < props.totalPages - 1) {
+    emit('pageChange', props.page + 1)
+  }
+}
+</script>
+
+<template>
+  <!-- Loading state -->
+  <div v-if="props.loading" class="flex items-center gap-2">
+    <CommonSpinner class="h-6 w-6 border-4" />
+    <span class="text-gray-600">{{ t('common.loading') }}</span>
+  </div>
+
+  <!-- Error state -->
+  <CommonAlert v-else-if="props.error" color="danger">
+    {{ props.error }}
+  </CommonAlert>
+
+  <!-- Empty state -->
+  <div v-else-if="props.empty">
+    <slot name="empty" />
+  </div>
+
+  <!-- Table -->
+  <div v-else>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+          <tr>
+            <slot name="header" />
+          </tr>
+        </thead>
+        <tbody class="bg-white divide-y divide-gray-200">
+          <slot name="rows" />
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Pagination -->
+    <div v-if="props.totalPages > 1" class="flex items-center justify-between mt-4">
+      <span class="text-sm text-gray-600">
+        {{ t('common.pagination', { page: props.page + 1, totalPages: props.totalPages }) }}
+      </span>
+      <div class="flex gap-2">
+        <button
+          :disabled="props.page === 0"
+          class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          @click="previousPage"
+        >
+          <ChevronLeftIcon class="h-4 w-4 mr-1" />
+          {{ t('common.previous') }}
+        </button>
+        <button
+          :disabled="props.page >= props.totalPages - 1"
+          class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+          @click="nextPage"
+        >
+          {{ t('common.next') }}
+          <ChevronRightIcon class="h-4 w-4 ml-1" />
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -31,11 +31,11 @@ async function logout() {
           {{ t('nav.users') }}
         </router-link>
       </li> -->
-      <!-- <li>
+      <li>
         <router-link to='/clients' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.clients') }}
         </router-link>
-      </li> -->
+      </li>
       <!-- <li>
         <router-link to='/configuration' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.configuration') }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -16,7 +16,10 @@
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "previous": "Previous",
+    "next": "Next",
+    "pagination": "Page {page} of {totalPages}"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -29,6 +32,14 @@
     "dashboard": {
       "title": "Dashboard",
       "welcome": "Welcome to the SympAuthy administration panel."
+    },
+    "clients": {
+      "title": "Clients",
+      "clientId": "Client ID",
+      "allowedScopes": "Allowed Scopes",
+      "defaultScopes": "Default Scopes",
+      "redirectUris": "Redirect URIs",
+      "empty": "No clients found."
     }
   }
 }

--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -25,16 +25,16 @@ onMounted(async () => {
       @page-change="clientStore.fetchClients"
     >
       <template #header>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="w-[10%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.clientId') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.allowedScopes') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.defaultScopes') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.redirectUris') }}
         </th>
       </template>

--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -1,0 +1,78 @@
+<script lang="ts" setup>
+import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useClientStore } from '@/stores/useClientStore'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+
+const { t } = useI18n()
+const clientStore = useClientStore()
+
+onMounted(async () => {
+  await clientStore.fetchClients()
+})
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-4">{{ t('pages.clients.title') }}</h1>
+
+    <PaginatedTable
+      :loading="clientStore.loading"
+      :error="clientStore.error"
+      :empty="clientStore.clients.length === 0"
+      :page="clientStore.page"
+      :total-pages="clientStore.totalPages"
+      @page-change="clientStore.fetchClients"
+    >
+      <template #header>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.clients.clientId') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.clients.allowedScopes') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.clients.defaultScopes') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.clients.redirectUris') }}
+        </th>
+      </template>
+
+      <template #rows>
+        <tr v-for="client in clientStore.clients" :key="client.client_id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {{ client.client_id }}
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500">
+            <span
+              v-for="scope in client.allowed_scopes"
+              :key="scope"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1"
+            >
+              {{ scope }}
+            </span>
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500">
+            <span
+              v-for="scope in client.default_scopes"
+              :key="scope"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 mr-1 mb-1"
+            >
+              {{ scope }}
+            </span>
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500">
+            <div v-for="uri in client.allowed_redirect_uris" :key="uri" class="truncate max-w-xs">
+              {{ uri }}
+            </div>
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.clients.empty') }}</p>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import DashboardPage from '@/pages/DashboardPage.vue'
+import ClientsPage from '@/pages/ClientsPage.vue'
 import CallbackPage from '@/pages/CallbackPage.vue'
 import { useAuthStore } from '@/stores/useAuthStore'
 
@@ -25,6 +26,12 @@ export function makeRouter() {
         path: '/',
         name: 'dashboard',
         component: DashboardPage,
+        meta: { requiresAuth: true }
+      },
+      {
+        path: '/clients',
+        name: 'clients',
+        component: ClientsPage,
         meta: { requiresAuth: true }
       }
     ]

--- a/src/stores/useClientStore.ts
+++ b/src/stores/useClientStore.ts
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { ClientApi } from '@/client/api/ClientApi'
+import type { ClientResource } from '@/client/model/ClientResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useClientStore = defineStore('clients', () => {
+  const api = new ClientApi()
+
+  const clients = ref<ClientResource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const page = ref(0)
+  const size = ref(20)
+  const total = ref(0)
+
+  const totalPages = computed(() => Math.ceil(total.value / size.value))
+
+  async function fetchClients(requestedPage: number = 0): Promise<void> {
+    loading.value = true
+    error.value = null
+
+    const response = await api.listClients(requestedPage, size.value)
+
+    if (isSuccess(response)) {
+      clients.value = response.content.clients
+      page.value = response.content.page
+      total.value = response.content.total
+    } else {
+      error.value = getErrorMessage(response as ErrorApiResponse)
+      clients.value = []
+    }
+
+    loading.value = false
+  }
+
+  return {
+    clients,
+    loading,
+    error,
+    page,
+    size,
+    total,
+    totalPages,
+    fetchClients,
+  }
+})


### PR DESCRIPTION
## Summary
- Add a paginated clients list page displaying configured OAuth2 clients from the admin API (`GET /api/v1/admin/clients`)
- Create a reusable slots-based `PaginatedTable` component with loading, error, empty states and pagination controls
- Extend `AbstractApi` with query parameter support
- Add OIDC scopes configuration for admin API access

## Test plan
- [ ] Navigate to `/clients` and verify the client list loads
- [ ] Verify loading spinner shows while fetching
- [ ] Verify error state displays if the API is unreachable
- [ ] Verify the sidebar "Clients" link is visible and active on the page
- [ ] Verify column widths are 10-30-30-30

🤖 Generated with [Claude Code](https://claude.com/claude-code)