### PR TITLE
Add claims list page

### DIFF
--- a/src/client/api/ClaimApi.ts
+++ b/src/client/api/ClaimApi.ts
@@ -1,0 +1,23 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type ClaimListResource,
+  claimListResourceSchema,
+} from '@/client/model/ClaimListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export class ClaimApi extends AbstractApi {
+  async listClaims(
+    page: number = 0,
+    size: number = 20,
+  ): Promise<SuccessApiResponse<ClaimListResource> | ErrorApiResponse> {
+    return this.get<ClaimListResource>({
+      path: '/api/v1/admin/claims',
+      params: {
+        page: page.toString(),
+        size: size.toString(),
+      },
+      schema: claimListResourceSchema,
+    })
+  }
+}

--- a/src/client/model/ClaimListResource.ts
+++ b/src/client/model/ClaimListResource.ts
@@ -1,0 +1,30 @@
+import type { JSONSchemaType } from 'ajv'
+import { type ClaimResource, claimResourceSchema } from '@/client/model/ClaimResource'
+
+export type ClaimListResource = {
+  claims: ClaimResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const claimListResourceSchema: JSONSchemaType<ClaimListResource> = {
+  type: 'object',
+  properties: {
+    claims: {
+      type: 'array',
+      items: { ...claimResourceSchema },
+    },
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    total: {
+      type: 'number',
+    },
+  },
+  required: ['claims', 'page', 'size', 'total'],
+  additionalProperties: true,
+}

--- a/src/client/model/ClaimResource.ts
+++ b/src/client/model/ClaimResource.ts
@@ -1,0 +1,43 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type ClaimResource = {
+  id: string
+  type: string
+  standard: boolean
+  enabled: boolean
+  required: boolean
+  allowed_values?: string[]
+  group?: string
+}
+
+export const claimResourceSchema: JSONSchemaType<ClaimResource> = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+    },
+    type: {
+      type: 'string',
+    },
+    standard: {
+      type: 'boolean',
+    },
+    enabled: {
+      type: 'boolean',
+    },
+    required: {
+      type: 'boolean',
+    },
+    allowed_values: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+    group: {
+      type: 'string',
+      nullable: true,
+    },
+  },
+  required: ['id', 'type', 'standard', 'enabled', 'required'],
+  additionalProperties: true,
+}

--- a/src/components/layout/AdminLayout.vue
+++ b/src/components/layout/AdminLayout.vue
@@ -3,7 +3,7 @@ import SidebarNav from '@/components/layout/SidebarNav.vue'
 </script>
 
 <template>
-  <div class='flex min-h-screen'>
+  <div class='flex h-screen'>
     <SidebarNav />
     <main class='flex-1 p-6 overflow-y-auto'>
       <slot />

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -36,6 +36,11 @@ async function logout() {
           {{ t('nav.clients') }}
         </router-link>
       </li>
+      <li>
+        <router-link to='/claims' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
+          {{ t('nav.claims') }}
+        </router-link>
+      </li>
       <!-- <li>
         <router-link to='/configuration' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.configuration') }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,7 @@
     "dashboard": "Dashboard",
     "users": "Users",
     "clients": "Clients",
+    "claims": "Claims",
     "configuration": "Configuration",
     "sessions": "Sessions"
   },
@@ -40,6 +41,17 @@
       "defaultScopes": "Default Scopes",
       "redirectUris": "Redirect URIs",
       "empty": "No clients found."
+    },
+    "claims": {
+      "title": "Claims",
+      "id": "ID",
+      "status": "Status",
+      "standard": "standard",
+      "custom": "custom",
+      "enabled": "enabled",
+      "disabled": "disabled",
+      "required": "required",
+      "empty": "No claims found."
     }
   }
 }

--- a/src/pages/ClaimsPage.vue
+++ b/src/pages/ClaimsPage.vue
@@ -1,0 +1,81 @@
+<script lang="ts" setup>
+import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useClaimStore } from '@/stores/useClaimStore'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+
+const { t } = useI18n()
+const claimStore = useClaimStore()
+
+onMounted(async () => {
+  await claimStore.fetchClaims()
+})
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-4">{{ t('pages.claims.title') }}</h1>
+
+    <PaginatedTable
+      :loading="claimStore.loading"
+      :error="claimStore.error"
+      :empty="claimStore.claims.length === 0"
+      :page="claimStore.page"
+      :total-pages="claimStore.totalPages"
+      @page-change="claimStore.fetchClaims"
+    >
+      <template #header>
+        <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.claims.id') }}
+        </th>
+        <th class="w-[70%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.claims.status') }}
+        </th>
+      </template>
+
+      <template #rows>
+        <tr v-for="claim in claimStore.claims" :key="claim.id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {{ claim.id }}
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500">
+            <span
+              v-if="claim.standard"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1"
+            >
+              {{ t('pages.claims.standard') }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 mr-1 mb-1"
+            >
+              {{ t('pages.claims.custom') }}
+            </span>
+            <span
+              v-if="claim.enabled"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 mr-1 mb-1"
+            >
+              {{ t('pages.claims.enabled') }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 mr-1 mb-1"
+            >
+              {{ t('pages.claims.disabled') }}
+            </span>
+            <span
+              v-if="claim.required"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 mr-1 mb-1"
+            >
+              {{ t('pages.claims.required') }}
+            </span>
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.claims.empty') }}</p>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import DashboardPage from '@/pages/DashboardPage.vue'
 import ClientsPage from '@/pages/ClientsPage.vue'
+import ClaimsPage from '@/pages/ClaimsPage.vue'
 import CallbackPage from '@/pages/CallbackPage.vue'
 import { useAuthStore } from '@/stores/useAuthStore'
 
@@ -32,6 +33,12 @@ export function makeRouter() {
         path: '/clients',
         name: 'clients',
         component: ClientsPage,
+        meta: { requiresAuth: true }
+      },
+      {
+        path: '/claims',
+        name: 'claims',
+        component: ClaimsPage,
         meta: { requiresAuth: true }
       }
     ]

--- a/src/stores/useClaimStore.ts
+++ b/src/stores/useClaimStore.ts
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { ClaimApi } from '@/client/api/ClaimApi'
+import type { ClaimResource } from '@/client/model/ClaimResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useClaimStore = defineStore('claims', () => {
+  const api = new ClaimApi()
+
+  const claims = ref<ClaimResource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const page = ref(0)
+  const size = ref(20)
+  const total = ref(0)
+
+  const totalPages = computed(() => Math.ceil(total.value / size.value))
+
+  async function fetchClaims(requestedPage: number = 0): Promise<void> {
+    loading.value = true
+    error.value = null
+
+    const response = await api.listClaims(requestedPage, size.value)
+
+    if (isSuccess(response)) {
+      claims.value = response.content.claims
+      page.value = response.content.page
+      total.value = response.content.total
+    } else {
+      error.value = getErrorMessage(response as ErrorApiResponse)
+      claims.value = []
+    }
+
+    loading.value = false
+  }
+
+  return {
+    claims,
+    loading,
+    error,
+    page,
+    size,
+    total,
+    totalPages,
+    fetchClaims,
+  }
+})


### PR DESCRIPTION
## Summary
- Add a paginated claims list page at `/claims` consuming `GET /api/v1/admin/claims`
- Display two columns: claim ID and status badges (standard/custom, enabled/disabled, required)
- Add sidebar navigation link, route, API client, Pinia store, and i18n translations
- Fix sidebar scrolling issue by constraining layout to viewport height

## Test plan
- [ ] Navigate to `/claims` and verify the table loads claims from the API
- [ ] Verify pagination controls work correctly
- [ ] Verify status badges display correctly (standard/custom, enabled/disabled, required)
- [ ] Verify the sidebar no longer scrolls when the table has many rows
- [ ] Verify error and empty states render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)