### PR TITLE
Add users list page with filtering and sorting

### DIFF
--- a/src/client/api/UserApi.ts
+++ b/src/client/api/UserApi.ts
@@ -1,0 +1,36 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type UserListResource,
+  userListResourceSchema,
+} from '@/client/model/UserListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export interface ListUsersParams {
+  page?: number
+  size?: number
+  claims?: string
+  q?: string
+  status?: string
+  sort?: string
+  order?: string
+  [key: string]: string | number | undefined
+}
+
+export class UserApi extends AbstractApi {
+  async listUsers(
+    params: ListUsersParams = {},
+  ): Promise<SuccessApiResponse<UserListResource> | ErrorApiResponse> {
+    const queryParams: Record<string, string> = {}
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        queryParams[key] = value.toString()
+      }
+    }
+    return this.get<UserListResource>({
+      path: '/api/v1/admin/users',
+      params: queryParams,
+      schema: userListResourceSchema,
+    })
+  }
+}

--- a/src/client/model/UserListResource.ts
+++ b/src/client/model/UserListResource.ts
@@ -1,0 +1,30 @@
+import type { JSONSchemaType } from 'ajv'
+import { type UserResource, userResourceSchema } from '@/client/model/UserResource'
+
+export type UserListResource = {
+  users: UserResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const userListResourceSchema: JSONSchemaType<UserListResource> = {
+  type: 'object',
+  properties: {
+    users: {
+      type: 'array',
+      items: { ...userResourceSchema },
+    },
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    total: {
+      type: 'number',
+    },
+  },
+  required: ['users', 'page', 'size', 'total'],
+  additionalProperties: true,
+}

--- a/src/client/model/UserResource.ts
+++ b/src/client/model/UserResource.ts
@@ -1,0 +1,33 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type UserResource = {
+  user_id: string
+  claims?: Record<string, string> | null
+  status: string
+  created_at: string
+}
+
+export const userResourceSchema: JSONSchemaType<UserResource> = {
+  type: 'object',
+  properties: {
+    user_id: {
+      type: 'string',
+    },
+    claims: {
+      type: 'object',
+      additionalProperties: {
+        type: 'string',
+      },
+      required: [],
+      nullable: true,
+    },
+    status: {
+      type: 'string',
+    },
+    created_at: {
+      type: 'string',
+    },
+  },
+  required: ['user_id', 'status', 'created_at'],
+  additionalProperties: true,
+}

--- a/src/components/DropdownButton.vue
+++ b/src/components/DropdownButton.vue
@@ -1,0 +1,71 @@
+<script lang="ts" setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue'
+import { ChevronDownIcon } from '@heroicons/vue/24/outline'
+
+withDefaults(
+  defineProps<{
+    label: string
+    disabled?: boolean
+    options: { label: string; value: string }[]
+  }>(),
+  {
+    disabled: false,
+  },
+)
+
+const emit = defineEmits<{
+  select: [value: string]
+}>()
+
+const open = ref(false)
+const dropdownRef = ref<HTMLElement>()
+
+function toggle() {
+  open.value = !open.value
+}
+
+function selectOption(value: string) {
+  emit('select', value)
+  open.value = false
+}
+
+function onClickOutside(event: MouseEvent) {
+  if (dropdownRef.value && !dropdownRef.value.contains(event.target as Node)) {
+    open.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', onClickOutside)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onClickOutside)
+})
+</script>
+
+<template>
+  <div ref="dropdownRef" class="relative">
+    <button
+      :disabled="disabled"
+      class="flex items-center gap-1 border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+      @click="toggle"
+    >
+      {{ label }}
+      <ChevronDownIcon class="h-4 w-4 text-gray-500" />
+    </button>
+    <div
+      v-if="open && options.length > 0"
+      class="absolute right-0 mt-1 min-w-full w-max bg-white border border-gray-200 rounded shadow-lg z-10"
+    >
+      <button
+        v-for="option in options"
+        :key="option.value"
+        class="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 first:rounded-t last:rounded-b"
+        @click="selectOption(option.value)"
+      >
+        {{ option.label }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
-import { reactive } from 'vue'
+import { reactive, computed } from 'vue'
 import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/vue/24/outline'
+import DropdownButton from '@/components/DropdownButton.vue'
 
 export type FilterConfig = {
   key: string
@@ -40,12 +41,14 @@ function onSearchInput(event: Event) {
   }, 300)
 }
 
-function addFilter(event: Event) {
-  const select = event.target as HTMLSelectElement
-  const key = select.value
-  if (!key) return
+const availableFilterOptions = computed(() =>
+  props.filters
+    .filter((f) => !activeFilters.has(f.key))
+    .map((f) => ({ label: f.label, value: f.key })),
+)
+
+function addFilter(key: string) {
   activeFilters.set(key, '')
-  select.value = ''
 }
 
 function onFilterValueChange(key: string, event: Event) {
@@ -86,20 +89,12 @@ function getFilterConfig(key: string): FilterConfig | undefined {
           @input="onSearchInput"
         />
       </div>
-      <select
-        :disabled="!filters.some((f) => !activeFilters.has(f.key))"
-        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-        @change="addFilter"
-      >
-        <option value="">{{ $t('pages.users.addFilter') }}</option>
-        <option
-          v-for="filter in filters.filter((f) => !activeFilters.has(f.key))"
-          :key="filter.key"
-          :value="filter.key"
-        >
-          {{ filter.label }}
-        </option>
-      </select>
+      <DropdownButton
+        :label="$t('pages.users.addFilter')"
+        :disabled="availableFilterOptions.length === 0"
+        :options="availableFilterOptions"
+        @select="addFilter"
+      />
     </div>
 
     <div v-if="activeFilters.size > 0" class="flex flex-wrap gap-2 mt-3">

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,26 +1,34 @@
 <script lang="ts" setup>
-import { MagnifyingGlassIcon } from '@heroicons/vue/24/outline'
+import { reactive } from 'vue'
+import { MagnifyingGlassIcon, XMarkIcon } from '@heroicons/vue/24/outline'
 
-export interface DropdownConfig {
-  value: string
-  options: { label: string; value: string }[]
-}
+export type FilterConfig = {
+  key: string
+  label: string
+} & (
+  | { type: 'text' }
+  | { type: 'select'; options: { label: string; value: string }[] }
+)
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     searchPlaceholder?: string
-    dropdowns?: DropdownConfig[]
+    filters?: FilterConfig[]
   }>(),
   {
     searchPlaceholder: '',
-    dropdowns: () => [],
+    filters: () => [],
   },
 )
 
 const emit = defineEmits<{
   search: [query: string]
-  'dropdown-change': [index: number, value: string]
+  'filter-change': [key: string, value: string]
+  'filter-remove': [key: string]
 }>()
+
+const activeFilters = reactive(new Map<string, string>())
+const filterTimeouts: Record<string, ReturnType<typeof setTimeout>> = {}
 
 let searchTimeout: ReturnType<typeof setTimeout> | undefined
 
@@ -32,40 +40,103 @@ function onSearchInput(event: Event) {
   }, 300)
 }
 
-function onDropdownChange(index: number, event: Event) {
-  const value = (event.target as HTMLSelectElement).value
-  emit('dropdown-change', index, value)
+function addFilter(event: Event) {
+  const select = event.target as HTMLSelectElement
+  const key = select.value
+  if (!key) return
+  activeFilters.set(key, '')
+  select.value = ''
+}
+
+function onFilterValueChange(key: string, event: Event) {
+  const filter = props.filters.find((f) => f.key === key)
+  const value = (event.target as HTMLInputElement | HTMLSelectElement).value
+  activeFilters.set(key, value)
+
+  if (filter && filter.type === 'text') {
+    if (filterTimeouts[key]) clearTimeout(filterTimeouts[key])
+    filterTimeouts[key] = setTimeout(() => {
+      emit('filter-change', key, value)
+    }, 300)
+  } else {
+    emit('filter-change', key, value)
+  }
+}
+
+function removeFilter(key: string) {
+  activeFilters.delete(key)
+  if (filterTimeouts[key]) clearTimeout(filterTimeouts[key])
+  emit('filter-remove', key)
+}
+
+function getFilterConfig(key: string): FilterConfig | undefined {
+  return props.filters.find((f) => f.key === key)
 }
 </script>
 
 <template>
   <div class="mb-4">
     <div class="flex items-center gap-4">
-      <div class="relative flex-1 max-w-md">
+      <div class="relative flex-1">
         <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
         <input
           type="text"
           :placeholder="searchPlaceholder"
-          class="w-full pl-9 pr-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+          class="w-full pl-9 pr-3 py-2 bg-white border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
           @input="onSearchInput"
         />
       </div>
       <select
-        v-for="(dropdown, index) in dropdowns"
-        :key="index"
-        :value="dropdown.value"
-        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-        @change="onDropdownChange(index, $event)"
+        :disabled="!filters.some((f) => !activeFilters.has(f.key))"
+        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        @change="addFilter"
       >
+        <option value="">{{ $t('pages.users.addFilter') }}</option>
         <option
-          v-for="option in dropdown.options"
-          :key="option.value"
-          :value="option.value"
+          v-for="filter in filters.filter((f) => !activeFilters.has(f.key))"
+          :key="filter.key"
+          :value="filter.key"
         >
-          {{ option.label }}
+          {{ filter.label }}
         </option>
       </select>
     </div>
-    <slot name="extra" />
+
+    <div v-if="activeFilters.size > 0" class="flex flex-wrap gap-2 mt-3">
+      <div
+        v-for="[key, value] in activeFilters"
+        :key="key"
+        class="flex items-center gap-1 border border-gray-300 rounded-full px-3 py-1 text-sm bg-gray-50"
+      >
+        <span class="text-gray-600 font-medium">{{ getFilterConfig(key)?.label }}:</span>
+        <select
+          v-if="getFilterConfig(key)?.type === 'select'"
+          :value="value"
+          class="border-none bg-white text-sm focus:outline-none focus:ring-0 py-0 pl-1 pr-6"
+          @change="onFilterValueChange(key, $event)"
+        >
+          <option
+            v-for="option in (getFilterConfig(key) as FilterConfig & { type: 'select' }).options"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+        <input
+          v-else
+          type="text"
+          :value="value"
+          class="border-none bg-white text-sm focus:outline-none focus:ring-0 py-0 px-1 w-24"
+          @input="onFilterValueChange(key, $event)"
+        />
+        <button
+          class="text-gray-400 hover:text-gray-600"
+          @click="removeFilter(key)"
+        >
+          <XMarkIcon class="h-4 w-4" />
+        </button>
+      </div>
+    </div>
   </div>
 </template>

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -1,0 +1,71 @@
+<script lang="ts" setup>
+import { MagnifyingGlassIcon } from '@heroicons/vue/24/outline'
+
+export interface DropdownConfig {
+  value: string
+  options: { label: string; value: string }[]
+}
+
+withDefaults(
+  defineProps<{
+    searchPlaceholder?: string
+    dropdowns?: DropdownConfig[]
+  }>(),
+  {
+    searchPlaceholder: '',
+    dropdowns: () => [],
+  },
+)
+
+const emit = defineEmits<{
+  search: [query: string]
+  'dropdown-change': [index: number, value: string]
+}>()
+
+let searchTimeout: ReturnType<typeof setTimeout> | undefined
+
+function onSearchInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    emit('search', value)
+  }, 300)
+}
+
+function onDropdownChange(index: number, event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  emit('dropdown-change', index, value)
+}
+</script>
+
+<template>
+  <div class="mb-4">
+    <div class="flex items-center gap-4">
+      <div class="relative flex-1 max-w-md">
+        <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          type="text"
+          :placeholder="searchPlaceholder"
+          class="w-full pl-9 pr-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+          @input="onSearchInput"
+        />
+      </div>
+      <select
+        v-for="(dropdown, index) in dropdowns"
+        :key="index"
+        :value="dropdown.value"
+        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        @change="onDropdownChange(index, $event)"
+      >
+        <option
+          v-for="option in dropdown.options"
+          :key="option.value"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+    </div>
+    <slot name="extra" />
+  </div>
+</template>

--- a/src/components/SortableHeader.vue
+++ b/src/components/SortableHeader.vue
@@ -1,0 +1,37 @@
+<script lang="ts" setup>
+import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/vue/24/outline'
+
+const props = defineProps<{
+  label: string
+  field: string
+  currentSort?: string
+  currentOrder?: string
+}>()
+
+const emit = defineEmits<{
+  sort: [field: string]
+}>()
+
+function onClick() {
+  emit('sort', props.field)
+}
+</script>
+
+<template>
+  <th
+    class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none hover:bg-gray-100"
+    @click="onClick"
+  >
+    <span class="inline-flex items-center gap-1">
+      {{ props.label }}
+      <ChevronUpIcon
+        v-if="props.currentSort === props.field && props.currentOrder === 'asc'"
+        class="h-3 w-3"
+      />
+      <ChevronDownIcon
+        v-else-if="props.currentSort === props.field && props.currentOrder === 'desc'"
+        class="h-3 w-3"
+      />
+    </span>
+  </th>
+</template>

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -26,11 +26,11 @@ async function logout() {
           {{ t('nav.dashboard') }}
         </router-link>
       </li>
-      <!-- <li>
+      <li>
         <router-link to='/users' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.users') }}
         </router-link>
-      </li> -->
+      </li>
       <li>
         <router-link to='/clients' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.clients') }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,8 +50,8 @@
       "disabled": "disabled",
       "empty": "No users found.",
       "search": "Search users...",
-      "statusFilter": "Status",
-      "allStatuses": "All statuses",
+      "statusFilter": "status",
+      "allStatuses": "all statuses",
       "addFilter": "Add filter"
     },
     "claims": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -42,6 +42,20 @@
       "redirectUris": "Redirect URIs",
       "empty": "No clients found."
     },
+    "users": {
+      "title": "Users",
+      "status": "Status",
+      "createdAt": "Created at",
+      "enabled": "enabled",
+      "disabled": "disabled",
+      "empty": "No users found.",
+      "search": "Search users...",
+      "statusFilter": "Status",
+      "allStatuses": "All statuses",
+      "claimFilters": "Claim filters",
+      "showFilters": "Show claim filters",
+      "hideFilters": "Hide claim filters"
+    },
     "claims": {
       "title": "Claims",
       "id": "ID",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,9 +52,7 @@
       "search": "Search users...",
       "statusFilter": "Status",
       "allStatuses": "All statuses",
-      "claimFilters": "Claim filters",
-      "showFilters": "Show claim filters",
-      "hideFilters": "Hide claim filters"
+      "addFilter": "Add filter"
     },
     "claims": {
       "title": "Claims",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,7 +63,8 @@
       "enabled": "enabled",
       "disabled": "disabled",
       "required": "required",
-      "empty": "No claims found."
+      "empty": "No claims found.",
+      "tags": "Tags"
     }
   }
 }

--- a/src/pages/ClaimsPage.vue
+++ b/src/pages/ClaimsPage.vue
@@ -25,47 +25,52 @@ onMounted(async () => {
       @page-change="claimStore.fetchClaims"
     >
       <template #header>
+        <th class="w-[10%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.claims.status') }}
+        </th>
         <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.claims.id') }}
         </th>
-        <th class="w-[70%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          {{ t('pages.claims.status') }}
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.claims.tags') }}
         </th>
       </template>
 
       <template #rows>
         <tr v-for="claim in claimStore.claims" :key="claim.id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <span
+              v-if="claim.enabled"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800"
+            >
+              {{ t('pages.claims.enabled') }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800"
+            >
+              {{ t('pages.claims.disabled') }}
+            </span>
+          </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
             {{ claim.id }}
           </td>
           <td class="px-6 py-4 text-sm text-gray-500">
             <span
               v-if="claim.standard"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1 mb-1"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800 mr-1"
             >
               {{ t('pages.claims.standard') }}
             </span>
             <span
               v-else
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 mr-1 mb-1"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800 mr-1"
             >
               {{ t('pages.claims.custom') }}
             </span>
             <span
-              v-if="claim.enabled"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 mr-1 mb-1"
-            >
-              {{ t('pages.claims.enabled') }}
-            </span>
-            <span
-              v-else
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800 mr-1 mb-1"
-            >
-              {{ t('pages.claims.disabled') }}
-            </span>
-            <span
               v-if="claim.required"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 mr-1 mb-1"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800"
             >
               {{ t('pages.claims.required') }}
             </span>

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -1,0 +1,171 @@
+<script lang="ts" setup>
+import { onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useUserStore } from '@/stores/useUserStore'
+import { useClaimStore } from '@/stores/useClaimStore'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+import SortableHeader from '@/components/SortableHeader.vue'
+import { MagnifyingGlassIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
+import type { ClaimResource } from '@/client/model/ClaimResource'
+
+const { t } = useI18n()
+const userStore = useUserStore()
+const claimStore = useClaimStore()
+
+const enabledClaims = ref<ClaimResource[]>([])
+const showClaimFilters = ref(false)
+
+let searchTimeout: ReturnType<typeof setTimeout> | undefined
+let claimFilterTimeouts: Record<string, ReturnType<typeof setTimeout>> = {}
+
+function onSearchInput(event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  if (searchTimeout) clearTimeout(searchTimeout)
+  searchTimeout = setTimeout(() => {
+    userStore.setSearch(value)
+  }, 300)
+}
+
+function onStatusChange(event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  userStore.setStatusFilter(value)
+}
+
+function onClaimFilterInput(claimId: string, event: Event) {
+  const value = (event.target as HTMLInputElement).value
+  if (claimFilterTimeouts[claimId]) clearTimeout(claimFilterTimeouts[claimId])
+  claimFilterTimeouts[claimId] = setTimeout(() => {
+    userStore.setClaimFilter(claimId, value)
+  }, 300)
+}
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString()
+}
+
+onMounted(async () => {
+  await claimStore.fetchClaims()
+  enabledClaims.value = claimStore.claims.filter((c) => c.enabled)
+  userStore.setSelectedClaimIds(enabledClaims.value.map((c) => c.id))
+  await userStore.fetchUsers()
+})
+</script>
+
+<template>
+  <div>
+    <h1 class="text-2xl font-bold mb-4">{{ t('pages.users.title') }}</h1>
+
+    <!-- Filter bar -->
+    <div class="flex items-center gap-4 mb-4">
+      <div class="relative flex-1 max-w-md">
+        <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          type="text"
+          :placeholder="t('pages.users.search')"
+          class="w-full pl-9 pr-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+          @input="onSearchInput"
+        />
+      </div>
+      <select
+        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+        @change="onStatusChange"
+      >
+        <option value="">{{ t('pages.users.allStatuses') }}</option>
+        <option value="enabled">{{ t('pages.users.enabled') }}</option>
+        <option value="disabled">{{ t('pages.users.disabled') }}</option>
+      </select>
+    </div>
+
+    <!-- Collapsible claim filters -->
+    <div v-if="enabledClaims.length > 0" class="mb-4">
+      <button
+        class="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
+        @click="showClaimFilters = !showClaimFilters"
+      >
+        <ChevronDownIcon v-if="!showClaimFilters" class="h-4 w-4" />
+        <ChevronUpIcon v-else class="h-4 w-4" />
+        {{ showClaimFilters ? t('pages.users.hideFilters') : t('pages.users.showFilters') }}
+      </button>
+      <div v-if="showClaimFilters" class="flex flex-wrap gap-3 mt-2">
+        <div v-for="claim in enabledClaims" :key="claim.id" class="flex flex-col">
+          <label class="text-xs text-gray-500 mb-1">{{ claim.id }}</label>
+          <input
+            type="text"
+            class="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+            @input="onClaimFilterInput(claim.id, $event)"
+          />
+        </div>
+      </div>
+    </div>
+
+    <PaginatedTable
+      :loading="userStore.loading"
+      :error="userStore.error"
+      :empty="userStore.users.length === 0"
+      :page="userStore.page"
+      :total-pages="userStore.totalPages"
+      @page-change="userStore.fetchUsers"
+    >
+      <template #header>
+        <SortableHeader
+          class="w-[10%]"
+          :label="t('pages.users.status')"
+          field="status"
+          :current-sort="userStore.sortField"
+          :current-order="userStore.sortOrder"
+          @sort="userStore.toggleSort"
+        />
+        <SortableHeader
+          v-for="claim in enabledClaims"
+          :key="claim.id"
+          :label="claim.id"
+          :field="claim.id"
+          :current-sort="userStore.sortField"
+          :current-order="userStore.sortOrder"
+          @sort="userStore.toggleSort"
+        />
+        <SortableHeader
+          class="w-[15%]"
+          :label="t('pages.users.createdAt')"
+          field="created_at"
+          :current-sort="userStore.sortField"
+          :current-order="userStore.sortOrder"
+          @sort="userStore.toggleSort"
+        />
+      </template>
+
+      <template #rows>
+        <tr v-for="user in userStore.users" :key="user.user_id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <span
+              v-if="user.status === 'enabled'"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800"
+            >
+              {{ t('pages.users.enabled') }}
+            </span>
+            <span
+              v-else
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800"
+            >
+              {{ t('pages.users.disabled') }}
+            </span>
+          </td>
+          <td
+            v-for="claim in enabledClaims"
+            :key="claim.id"
+            class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"
+          >
+            {{ user.claims?.[claim.id] ?? '' }}
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            {{ formatDate(user.created_at) }}
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.users.empty') }}</p>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -6,7 +6,7 @@ import { useClaimStore } from '@/stores/useClaimStore'
 import PaginatedTable from '@/components/PaginatedTable.vue'
 import SortableHeader from '@/components/SortableHeader.vue'
 import FilterBar from '@/components/FilterBar.vue'
-import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
+import type { FilterConfig } from '@/components/FilterBar.vue'
 import type { ClaimResource } from '@/client/model/ClaimResource'
 
 const { t } = useI18n()
@@ -14,31 +14,39 @@ const userStore = useUserStore()
 const claimStore = useClaimStore()
 
 const enabledClaims = ref<ClaimResource[]>([])
-const showClaimFilters = ref(false)
 
-let claimFilterTimeouts: Record<string, ReturnType<typeof setTimeout>> = {}
-
-const statusDropdowns = computed(() => [
+const filters = computed<FilterConfig[]>(() => [
   {
-    value: userStore.statusFilter,
+    key: 'status',
+    label: t('pages.users.status'),
+    type: 'select',
     options: [
       { label: t('pages.users.allStatuses'), value: '' },
       { label: t('pages.users.enabled'), value: 'enabled' },
       { label: t('pages.users.disabled'), value: 'disabled' },
     ],
   },
+  ...enabledClaims.value.map((claim) => ({
+    key: claim.id,
+    label: claim.id,
+    type: 'text' as const,
+  })),
 ])
 
-function onDropdownChange(_index: number, value: string) {
-  userStore.setStatusFilter(value)
+function onFilterChange(key: string, value: string) {
+  if (key === 'status') {
+    userStore.setStatusFilter(value)
+  } else {
+    userStore.setClaimFilter(key, value)
+  }
 }
 
-function onClaimFilterInput(claimId: string, event: Event) {
-  const value = (event.target as HTMLInputElement).value
-  if (claimFilterTimeouts[claimId]) clearTimeout(claimFilterTimeouts[claimId])
-  claimFilterTimeouts[claimId] = setTimeout(() => {
-    userStore.setClaimFilter(claimId, value)
-  }, 300)
+function onFilterRemove(key: string) {
+  if (key === 'status') {
+    userStore.clearStatusFilter()
+  } else {
+    userStore.clearClaimFilter(key)
+  }
 }
 
 function formatDate(dateStr: string): string {
@@ -59,33 +67,11 @@ onMounted(async () => {
 
     <FilterBar
       :search-placeholder="t('pages.users.search')"
-      :dropdowns="statusDropdowns"
+      :filters="filters"
       @search="userStore.setSearch"
-      @dropdown-change="onDropdownChange"
-    >
-      <template #extra>
-        <div v-if="enabledClaims.length > 0" class="mt-3">
-          <button
-            class="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
-            @click="showClaimFilters = !showClaimFilters"
-          >
-            <ChevronDownIcon v-if="!showClaimFilters" class="h-4 w-4" />
-            <ChevronUpIcon v-else class="h-4 w-4" />
-            {{ showClaimFilters ? t('pages.users.hideFilters') : t('pages.users.showFilters') }}
-          </button>
-          <div v-if="showClaimFilters" class="flex flex-wrap gap-3 mt-2">
-            <div v-for="claim in enabledClaims" :key="claim.id" class="flex flex-col">
-              <label class="text-xs text-gray-500 mb-1">{{ claim.id }}</label>
-              <input
-                type="text"
-                class="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-                @input="onClaimFilterInput(claim.id, $event)"
-              />
-            </div>
-          </div>
-        </div>
-      </template>
-    </FilterBar>
+      @filter-change="onFilterChange"
+      @filter-remove="onFilterRemove"
+    />
 
     <PaginatedTable
       :loading="userStore.loading"

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -1,11 +1,12 @@
 <script lang="ts" setup>
-import { onMounted, ref } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useUserStore } from '@/stores/useUserStore'
 import { useClaimStore } from '@/stores/useClaimStore'
 import PaginatedTable from '@/components/PaginatedTable.vue'
 import SortableHeader from '@/components/SortableHeader.vue'
-import { MagnifyingGlassIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
+import FilterBar from '@/components/FilterBar.vue'
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/vue/24/outline'
 import type { ClaimResource } from '@/client/model/ClaimResource'
 
 const { t } = useI18n()
@@ -15,19 +16,20 @@ const claimStore = useClaimStore()
 const enabledClaims = ref<ClaimResource[]>([])
 const showClaimFilters = ref(false)
 
-let searchTimeout: ReturnType<typeof setTimeout> | undefined
 let claimFilterTimeouts: Record<string, ReturnType<typeof setTimeout>> = {}
 
-function onSearchInput(event: Event) {
-  const value = (event.target as HTMLInputElement).value
-  if (searchTimeout) clearTimeout(searchTimeout)
-  searchTimeout = setTimeout(() => {
-    userStore.setSearch(value)
-  }, 300)
-}
+const statusDropdowns = computed(() => [
+  {
+    value: userStore.statusFilter,
+    options: [
+      { label: t('pages.users.allStatuses'), value: '' },
+      { label: t('pages.users.enabled'), value: 'enabled' },
+      { label: t('pages.users.disabled'), value: 'disabled' },
+    ],
+  },
+])
 
-function onStatusChange(event: Event) {
-  const value = (event.target as HTMLSelectElement).value
+function onDropdownChange(_index: number, value: string) {
   userStore.setStatusFilter(value)
 }
 
@@ -55,48 +57,35 @@ onMounted(async () => {
   <div>
     <h1 class="text-2xl font-bold mb-4">{{ t('pages.users.title') }}</h1>
 
-    <!-- Filter bar -->
-    <div class="flex items-center gap-4 mb-4">
-      <div class="relative flex-1 max-w-md">
-        <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
-        <input
-          type="text"
-          :placeholder="t('pages.users.search')"
-          class="w-full pl-9 pr-3 py-2 border border-gray-300 rounded text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-          @input="onSearchInput"
-        />
-      </div>
-      <select
-        class="border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-        @change="onStatusChange"
-      >
-        <option value="">{{ t('pages.users.allStatuses') }}</option>
-        <option value="enabled">{{ t('pages.users.enabled') }}</option>
-        <option value="disabled">{{ t('pages.users.disabled') }}</option>
-      </select>
-    </div>
-
-    <!-- Collapsible claim filters -->
-    <div v-if="enabledClaims.length > 0" class="mb-4">
-      <button
-        class="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
-        @click="showClaimFilters = !showClaimFilters"
-      >
-        <ChevronDownIcon v-if="!showClaimFilters" class="h-4 w-4" />
-        <ChevronUpIcon v-else class="h-4 w-4" />
-        {{ showClaimFilters ? t('pages.users.hideFilters') : t('pages.users.showFilters') }}
-      </button>
-      <div v-if="showClaimFilters" class="flex flex-wrap gap-3 mt-2">
-        <div v-for="claim in enabledClaims" :key="claim.id" class="flex flex-col">
-          <label class="text-xs text-gray-500 mb-1">{{ claim.id }}</label>
-          <input
-            type="text"
-            class="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
-            @input="onClaimFilterInput(claim.id, $event)"
-          />
+    <FilterBar
+      :search-placeholder="t('pages.users.search')"
+      :dropdowns="statusDropdowns"
+      @search="userStore.setSearch"
+      @dropdown-change="onDropdownChange"
+    >
+      <template #extra>
+        <div v-if="enabledClaims.length > 0" class="mt-3">
+          <button
+            class="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900"
+            @click="showClaimFilters = !showClaimFilters"
+          >
+            <ChevronDownIcon v-if="!showClaimFilters" class="h-4 w-4" />
+            <ChevronUpIcon v-else class="h-4 w-4" />
+            {{ showClaimFilters ? t('pages.users.hideFilters') : t('pages.users.showFilters') }}
+          </button>
+          <div v-if="showClaimFilters" class="flex flex-wrap gap-3 mt-2">
+            <div v-for="claim in enabledClaims" :key="claim.id" class="flex flex-col">
+              <label class="text-xs text-gray-500 mb-1">{{ claim.id }}</label>
+              <input
+                type="text"
+                class="border border-gray-300 rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+                @input="onClaimFilterInput(claim.id, $event)"
+              />
+            </div>
+          </div>
         </div>
-      </div>
-    </div>
+      </template>
+    </FilterBar>
 
     <PaginatedTable
       :loading="userStore.loading"

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -18,7 +18,7 @@ const enabledClaims = ref<ClaimResource[]>([])
 const filters = computed<FilterConfig[]>(() => [
   {
     key: 'status',
-    label: t('pages.users.status'),
+    label: t('pages.users.statusFilter'),
     type: 'select',
     options: [
       { label: t('pages.users.allStatuses'), value: '' },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import DashboardPage from '@/pages/DashboardPage.vue'
 import ClientsPage from '@/pages/ClientsPage.vue'
 import ClaimsPage from '@/pages/ClaimsPage.vue'
+import UsersPage from '@/pages/UsersPage.vue'
 import CallbackPage from '@/pages/CallbackPage.vue'
 import { useAuthStore } from '@/stores/useAuthStore'
 
@@ -27,6 +28,12 @@ export function makeRouter() {
         path: '/',
         name: 'dashboard',
         component: DashboardPage,
+        meta: { requiresAuth: true }
+      },
+      {
+        path: '/users',
+        name: 'users',
+        component: UsersPage,
         meta: { requiresAuth: true }
       },
       {

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -1,0 +1,123 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { UserApi } from '@/client/api/UserApi'
+import type { UserResource } from '@/client/model/UserResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useUserStore = defineStore('users', () => {
+  const api = new UserApi()
+
+  const users = ref<UserResource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const page = ref(0)
+  const size = ref(20)
+  const total = ref(0)
+
+  const searchQuery = ref('')
+  const statusFilter = ref('')
+  const claimFilters = ref<Record<string, string>>({})
+  const sortField = ref('')
+  const sortOrder = ref('')
+  const selectedClaimIds = ref<string[]>([])
+
+  const totalPages = computed(() => Math.ceil(total.value / size.value))
+
+  async function fetchUsers(requestedPage: number = 0): Promise<void> {
+    loading.value = true
+    error.value = null
+
+    const params: Record<string, string | number | undefined> = {
+      page: requestedPage,
+      size: size.value,
+    }
+
+    if (selectedClaimIds.value.length > 0) {
+      params.claims = selectedClaimIds.value.join(',')
+    }
+    if (searchQuery.value) {
+      params.q = searchQuery.value
+    }
+    if (statusFilter.value) {
+      params.status = statusFilter.value
+    }
+    if (sortField.value) {
+      params.sort = sortField.value
+      params.order = sortOrder.value || 'asc'
+    }
+
+    for (const [claimId, value] of Object.entries(claimFilters.value)) {
+      if (value) {
+        params[claimId] = value
+      }
+    }
+
+    const response = await api.listUsers(params)
+
+    if (isSuccess(response)) {
+      users.value = response.content.users
+      page.value = response.content.page
+      total.value = response.content.total
+    } else {
+      error.value = getErrorMessage(response as ErrorApiResponse)
+      users.value = []
+    }
+
+    loading.value = false
+  }
+
+  function setSearch(q: string) {
+    searchQuery.value = q
+    fetchUsers(0)
+  }
+
+  function setStatusFilter(status: string) {
+    statusFilter.value = status
+    fetchUsers(0)
+  }
+
+  function setClaimFilter(claimId: string, value: string) {
+    claimFilters.value[claimId] = value
+    fetchUsers(0)
+  }
+
+  function toggleSort(field: string) {
+    if (sortField.value !== field) {
+      sortField.value = field
+      sortOrder.value = 'asc'
+    } else if (sortOrder.value === 'asc') {
+      sortOrder.value = 'desc'
+    } else {
+      sortField.value = ''
+      sortOrder.value = ''
+    }
+    fetchUsers(0)
+  }
+
+  function setSelectedClaimIds(claimIds: string[]) {
+    selectedClaimIds.value = claimIds
+  }
+
+  return {
+    users,
+    loading,
+    error,
+    page,
+    size,
+    total,
+    totalPages,
+    searchQuery,
+    statusFilter,
+    claimFilters,
+    sortField,
+    sortOrder,
+    selectedClaimIds,
+    fetchUsers,
+    setSearch,
+    setStatusFilter,
+    setClaimFilter,
+    toggleSort,
+    setSelectedClaimIds,
+  }
+})

--- a/src/stores/useUserStore.ts
+++ b/src/stores/useUserStore.ts
@@ -95,6 +95,16 @@ export const useUserStore = defineStore('users', () => {
     fetchUsers(0)
   }
 
+  function clearStatusFilter() {
+    statusFilter.value = ''
+    fetchUsers(0)
+  }
+
+  function clearClaimFilter(claimId: string) {
+    delete claimFilters.value[claimId]
+    fetchUsers(0)
+  }
+
   function setSelectedClaimIds(claimIds: string[]) {
     selectedClaimIds.value = claimIds
   }
@@ -117,6 +127,8 @@ export const useUserStore = defineStore('users', () => {
     setSearch,
     setStatusFilter,
     setClaimFilter,
+    clearStatusFilter,
+    clearClaimFilter,
     toggleSort,
     setSelectedClaimIds,
   }


### PR DESCRIPTION
## Summary
- Add users list page with paginated table, search, sorting, and filtering by status and claims
- Create reusable `FilterBar` component with "Add filter" dropdown that creates removable filter chips
- Create custom `DropdownButton` component to replace native browser select
- Move enabled/disabled status to first column in claims list for consistency

## Test plan
- [x] Navigate to `/users` — paginated table displays with status, claims, and created at columns
- [x] Search input filters users with 300ms debounce
- [x] "Add filter" dropdown shows available filters; selecting one adds a chip
- [x] Status chip shows a select input (all statuses/enabled/disabled)
- [x] Claim chips show text inputs with debounce
- [x] Removing a chip clears the filter and returns it to the dropdown
- [x] Column headers are sortable (asc/desc/none)
- [x] Claims list now shows status as first column

🤖 Generated with [Claude Code](https://claude.com/claude-code)