### PR TITLE
Add identifier field to claims table

### DIFF
--- a/src/client/model/ClaimResource.ts
+++ b/src/client/model/ClaimResource.ts
@@ -6,6 +6,7 @@ export type ClaimResource = {
   standard: boolean
   enabled: boolean
   required: boolean
+  identifier: boolean
   allowed_values?: string[]
   group?: string
 }
@@ -28,6 +29,9 @@ export const claimResourceSchema: JSONSchemaType<ClaimResource> = {
     required: {
       type: 'boolean',
     },
+    identifier: {
+      type: 'boolean',
+    },
     allowed_values: {
       type: 'array',
       items: { type: 'string' },
@@ -38,6 +42,6 @@ export const claimResourceSchema: JSONSchemaType<ClaimResource> = {
       nullable: true,
     },
   },
-  required: ['id', 'type', 'standard', 'enabled', 'required'],
+  required: ['id', 'type', 'standard', 'enabled', 'required', 'identifier'],
   additionalProperties: true,
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,6 +71,7 @@
       "enabled": "enabled",
       "disabled": "disabled",
       "required": "required",
+      "identifier": "identifier",
       "empty": "No claims found.",
       "tags": "Tags"
     }

--- a/src/pages/ClaimsPage.vue
+++ b/src/pages/ClaimsPage.vue
@@ -70,9 +70,15 @@ onMounted(async () => {
             </span>
             <span
               v-if="claim.required"
-              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 mr-1"
             >
               {{ t('pages.claims.required') }}
+            </span>
+            <span
+              v-if="claim.identifier"
+              class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-800"
+            >
+              {{ t('pages.claims.identifier') }}
             </span>
           </td>
         </tr>


### PR DESCRIPTION
## Summary

- Add `identifier` boolean field to `ClaimResource` model and AJV schema
- Display an "identifier" badge (yellow) in the claims table tags column
- Add i18n translation for the new tag

Relates to sympauthy/sympauthy#143

## Test plan

- [x] Verify the claims table renders the identifier badge for claims marked as identifiers
- [x] Verify claims without `identifier: true` do not show the badge
- [x] Verify the build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)