### PR TITLE
Add List Scopes admin page

### DIFF
--- a/src/client/api/ScopeApi.ts
+++ b/src/client/api/ScopeApi.ts
@@ -1,0 +1,32 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type ScopeListResource,
+  scopeListResourceSchema,
+} from '@/client/model/ScopeListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export class ScopeApi extends AbstractApi {
+  async listScopes(
+    page: number = 0,
+    size: number = 20,
+    type?: string,
+    enabled?: string,
+  ): Promise<SuccessApiResponse<ScopeListResource> | ErrorApiResponse> {
+    const params: Record<string, string> = {
+      page: page.toString(),
+      size: size.toString(),
+    }
+    if (type) {
+      params.type = type
+    }
+    if (enabled) {
+      params.enabled = enabled
+    }
+    return this.get<ScopeListResource>({
+      path: '/api/v1/admin/scopes',
+      params,
+      schema: scopeListResourceSchema,
+    })
+  }
+}

--- a/src/client/model/ScopeListResource.ts
+++ b/src/client/model/ScopeListResource.ts
@@ -1,0 +1,30 @@
+import type { JSONSchemaType } from 'ajv'
+import { type ScopeResource, scopeResourceSchema } from '@/client/model/ScopeResource'
+
+export type ScopeListResource = {
+  scopes: ScopeResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const scopeListResourceSchema: JSONSchemaType<ScopeListResource> = {
+  type: 'object',
+  properties: {
+    scopes: {
+      type: 'array',
+      items: { ...scopeResourceSchema },
+    },
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    total: {
+      type: 'number',
+    },
+  },
+  required: ['scopes', 'page', 'size', 'total'],
+  additionalProperties: true,
+}

--- a/src/client/model/ScopeResource.ts
+++ b/src/client/model/ScopeResource.ts
@@ -1,0 +1,34 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type ScopeResource = {
+  id: string
+  type: string
+  origin: string
+  enabled: boolean
+  claims?: string[]
+}
+
+export const scopeResourceSchema: JSONSchemaType<ScopeResource> = {
+  type: 'object',
+  properties: {
+    id: {
+      type: 'string',
+    },
+    type: {
+      type: 'string',
+    },
+    origin: {
+      type: 'string',
+    },
+    enabled: {
+      type: 'boolean',
+    },
+    claims: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+  },
+  required: ['id', 'type', 'origin', 'enabled'],
+  additionalProperties: true,
+}

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -41,6 +41,11 @@ async function logout() {
           {{ t('nav.claims') }}
         </router-link>
       </li>
+      <li>
+        <router-link to='/scopes' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
+          {{ t('nav.scopes') }}
+        </router-link>
+      </li>
       <!-- <li>
         <router-link to='/configuration' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.configuration') }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,6 +27,7 @@
     "users": "Users",
     "clients": "Clients",
     "claims": "Claims",
+    "scopes": "Scopes",
     "configuration": "Configuration",
     "sessions": "Sessions"
   },
@@ -107,6 +108,30 @@
       "actions": "Actions",
       "revoke": "Revoke",
       "noConsents": "No active consents."
+    },
+    "scopes": {
+      "title": "Scopes",
+      "id": "ID",
+      "status": "Status",
+      "type": "Type",
+      "origin": {
+        "label": "Origin",
+        "oauth2": "oauth2",
+        "openid": "openid",
+        "system": "system",
+        "custom": "custom"
+      },
+      "claims": "Claims",
+      "enabled": "enabled",
+      "disabled": "disabled",
+      "consentable": "consentable",
+      "grantable": "grantable",
+      "client": "client",
+      "typeFilter": "type",
+      "allTypes": "all types",
+      "statusFilter": "status",
+      "allStatuses": "all statuses",
+      "empty": "No scopes found."
     },
     "claims": {
       "title": "Claims",

--- a/src/pages/ScopesPage.vue
+++ b/src/pages/ScopesPage.vue
@@ -1,0 +1,153 @@
+<script lang="ts" setup>
+import { computed, onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useScopeStore } from '@/stores/useScopeStore'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+import FilterBar from '@/components/FilterBar.vue'
+import Tag from '@/components/Tag.vue'
+import type { FilterConfig } from '@/components/FilterBar.vue'
+
+const { t } = useI18n()
+const scopeStore = useScopeStore()
+
+const filters = computed<FilterConfig[]>(() => [
+  {
+    key: 'type',
+    label: t('pages.scopes.typeFilter'),
+    type: 'select',
+    options: [
+      { label: t('pages.scopes.allTypes'), value: '' },
+      { label: t('pages.scopes.consentable'), value: 'consentable' },
+      { label: t('pages.scopes.grantable'), value: 'grantable' },
+      { label: t('pages.scopes.client'), value: 'client' },
+    ],
+  },
+  {
+    key: 'enabled',
+    label: t('pages.scopes.statusFilter'),
+    type: 'select',
+    options: [
+      { label: t('pages.scopes.allStatuses'), value: '' },
+      { label: t('pages.scopes.enabled'), value: 'true' },
+      { label: t('pages.scopes.disabled'), value: 'false' },
+    ],
+  },
+])
+
+function onFilterChange(key: string, value: string) {
+  if (key === 'type') {
+    scopeStore.setTypeFilter(value)
+  } else if (key === 'enabled') {
+    scopeStore.setEnabledFilter(value)
+  }
+}
+
+function onFilterRemove(key: string) {
+  if (key === 'type') {
+    scopeStore.clearTypeFilter()
+  } else if (key === 'enabled') {
+    scopeStore.clearEnabledFilter()
+  }
+}
+
+function typeColor(type: string): 'blue' | 'purple' | 'gray' {
+  switch (type) {
+    case 'consentable':
+      return 'blue'
+    case 'grantable':
+      return 'purple'
+    default:
+      return 'gray'
+  }
+}
+
+function originColor(origin: string): 'blue' | 'gray' | 'yellow' {
+  switch (origin) {
+    case 'openid':
+    case 'oauth2':
+      return 'blue'
+    case 'custom':
+      return 'yellow'
+    default:
+      return 'gray'
+  }
+}
+
+onMounted(async () => {
+  await scopeStore.fetchScopes()
+})
+</script>
+
+<template>
+  <div>
+    <FilterBar
+      :filters="filters"
+      @filter-change="onFilterChange"
+      @filter-remove="onFilterRemove"
+    />
+
+    <PaginatedTable
+      :loading="scopeStore.loading"
+      :error="scopeStore.error"
+      :empty="scopeStore.scopes.length === 0"
+      :page="scopeStore.page"
+      :total-pages="scopeStore.totalPages"
+      table-layout="auto"
+      @page-change="scopeStore.fetchScopes"
+    >
+      <template #header>
+        <th class="w-0 whitespace-nowrap px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.scopes.status') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.scopes.id') }}
+        </th>
+        <th class="w-0 whitespace-nowrap px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.scopes.type') }}
+        </th>
+        <th class="w-0 whitespace-nowrap px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.scopes.origin.label') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.scopes.claims') }}
+        </th>
+      </template>
+
+      <template #rows>
+        <tr v-for="scope in scopeStore.scopes" :key="scope.id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <Tag v-if="scope.enabled" color="green">
+              {{ t('pages.scopes.enabled') }}
+            </Tag>
+            <Tag v-else color="red">
+              {{ t('pages.scopes.disabled') }}
+            </Tag>
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {{ scope.id }}
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <Tag :color="typeColor(scope.type)">
+              {{ t(`pages.scopes.${scope.type}`) }}
+            </Tag>
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <Tag :color="originColor(scope.origin)">
+              {{ t(`pages.scopes.origin.${scope.origin}`) }}
+            </Tag>
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500">
+            <span v-if="scope.claims && scope.claims.length > 0">
+              {{ scope.claims.join(', ') }}
+            </span>
+            <span v-else class="text-gray-300">&mdash;</span>
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.scopes.empty') }}</p>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import DashboardPage from '@/pages/DashboardPage.vue'
 import ClientsPage from '@/pages/ClientsPage.vue'
 import ClaimsPage from '@/pages/ClaimsPage.vue'
+import ScopesPage from '@/pages/ScopesPage.vue'
 import UsersPage from '@/pages/UsersPage.vue'
 import UserDetailPage from '@/pages/userdetail/UserDetailPage.vue'
 import CallbackPage from '@/pages/CallbackPage.vue'
@@ -58,6 +59,12 @@ export function makeRouter() {
         name: 'claims',
         component: ClaimsPage,
         meta: { requiresAuth: true, breadcrumb: { label: 'nav.claims' } }
+      },
+      {
+        path: '/scopes',
+        name: 'scopes',
+        component: ScopesPage,
+        meta: { requiresAuth: true, breadcrumb: { label: 'nav.scopes' } }
       }
     ]
   })

--- a/src/stores/useScopeStore.ts
+++ b/src/stores/useScopeStore.ts
@@ -1,0 +1,82 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { ScopeApi } from '@/client/api/ScopeApi'
+import type { ScopeResource } from '@/client/model/ScopeResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useScopeStore = defineStore('scopes', () => {
+  const api = new ScopeApi()
+
+  const scopes = ref<ScopeResource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const page = ref(0)
+  const size = ref(20)
+  const total = ref(0)
+
+  const typeFilter = ref('')
+  const enabledFilter = ref('')
+
+  const totalPages = computed(() => Math.ceil(total.value / size.value))
+
+  async function fetchScopes(requestedPage: number = 0): Promise<void> {
+    loading.value = true
+    error.value = null
+
+    const response = await api.listScopes(
+      requestedPage,
+      size.value,
+      typeFilter.value || undefined,
+      enabledFilter.value || undefined,
+    )
+
+    if (isSuccess(response)) {
+      scopes.value = response.content.scopes
+      page.value = response.content.page
+      total.value = response.content.total
+    } else {
+      error.value = getErrorMessage(response as ErrorApiResponse)
+      scopes.value = []
+    }
+
+    loading.value = false
+  }
+
+  function setTypeFilter(value: string) {
+    typeFilter.value = value
+    fetchScopes(0)
+  }
+
+  function setEnabledFilter(value: string) {
+    enabledFilter.value = value
+    fetchScopes(0)
+  }
+
+  function clearTypeFilter() {
+    typeFilter.value = ''
+    fetchScopes(0)
+  }
+
+  function clearEnabledFilter() {
+    enabledFilter.value = ''
+    fetchScopes(0)
+  }
+
+  return {
+    scopes,
+    loading,
+    error,
+    page,
+    size,
+    total,
+    totalPages,
+    typeFilter,
+    enabledFilter,
+    fetchScopes,
+    setTypeFilter,
+    setEnabledFilter,
+    clearTypeFilter,
+    clearEnabledFilter,
+  }
+})


### PR DESCRIPTION
## Summary
- Add new `/scopes` page listing all configured scopes from `GET /api/v1/admin/scopes`
- Filterable by scope type (consentable/grantable/client) and enabled status
- Displays status, ID, type, origin, and associated claims (for consentable scopes)
- Follows existing ClaimsPage/UsersPage patterns (API class, AJV schema, Pinia store, PaginatedTable + FilterBar)

Closes sympauthy/sympauthy#160

## Test plan
- [x] Verify the Scopes nav link appears in the sidebar after Claims
- [x] Verify the scopes table loads and displays data from the API
- [x] Verify type and enabled filters work correctly
- [x] Verify pagination works
- [x] Verify claims column shows claim IDs for consentable scopes and a dash for others

🤖 Generated with [Claude Code](https://claude.com/claude-code)