### PR TITLE
Add responsive design for phones, tablets, and desktops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,12 @@ Key patterns:
 - `AdminLayout` handles the drawer overlay and mobile header bar (`lg:hidden`)
 - `SidebarNav` sizing is controlled by its parent (`h-full w-full`), not by the component itself
 - Table cell padding is reduced on phones via a global CSS rule in `style.css` (avoids per-page changes)
-- Avoid fixed percentage widths on table columns — use `table-layout="auto"` and let `overflow-x-auto` handle overflow
+- `PaginatedTable` defaults to `table-layout="auto"` — do not use `fixed`
+- Table column sizing convention:
+  - **Shrink-wrap columns** (status, dates, actions): use `w-0 whitespace-nowrap` on `<th>` so they take only the space their content needs
+  - **Fill columns** (names, emails, values): no width classes — they expand to fill remaining space. Add `truncate` on `<td>` to ellipsize overflow
+  - **Hidden on phone**: use `hidden sm:table-cell` on both `<th>` and `<td>` (e.g. "Created At" in users list)
+  - Never use fixed percentage widths (`w-[10%]`, `w-[100px]`) — they break at different breakpoints
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,20 @@ Responses are `SuccessApiResponse<T> | ErrorApiResponse`, checked with `isSucces
 - `Tag` component for status badges
 - In data tables, the primary/ID column uses `font-medium text-gray-900` for bold styling (not `Tag`)
 
+## Responsive Design
+
+Mobile-first approach using Tailwind's default breakpoints:
+- **Base (< 640px)** — Phones: sidebar is a slide-over drawer toggled by hamburger menu, tables scroll horizontally, filters and pagination stack vertically
+- **`sm:` (≥ 640px)** — Large phones / small tablets: filters and pagination go side-by-side
+- **`lg:` (≥ 1024px)** — Desktops: sidebar is permanently visible, full padding (`p-6`, `px-6`)
+
+Key patterns:
+- Sidebar state managed by `useSidebar` composable (shared `ref`, auto-closes on navigation)
+- `AdminLayout` handles the drawer overlay and mobile header bar (`lg:hidden`)
+- `SidebarNav` sizing is controlled by its parent (`h-full w-full`), not by the component itself
+- Table cell padding is reduced on phones via a global CSS rule in `style.css` (avoids per-page changes)
+- Avoid fixed percentage widths on table columns — use `table-layout="auto"` and let `overflow-x-auto` handle overflow
+
 ## Environment
 
 OIDC config via `VITE_OIDC_*` env vars (see `.env.local`). Dev proxy forwards `/api` and `/.well-known` to the backend.

--- a/src/components/FilterBar.vue
+++ b/src/components/FilterBar.vue
@@ -79,7 +79,7 @@ function getFilterConfig(key: string): FilterConfig | undefined {
 
 <template>
   <div class="mb-4">
-    <div class="flex items-center gap-4">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
       <div class="relative flex-1">
         <MagnifyingGlassIcon class="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
         <input

--- a/src/components/HelpTooltip.vue
+++ b/src/components/HelpTooltip.vue
@@ -23,7 +23,7 @@ onUnmounted(() => document.removeEventListener('click', onClickOutside))
     <button @click.stop="toggle" class="text-current opacity-60 hover:opacity-100 cursor-help text-[0.85em] font-semibold leading-none whitespace-nowrap align-middle" type="button">&nbsp;ⓘ</button>
     <div
       v-if="open"
-      class="absolute top-full left-1/2 -translate-x-1/2 mt-1 z-50 w-72 p-3 text-sm text-gray-700 bg-white border border-gray-200 rounded-lg shadow-lg normal-case tracking-normal font-normal"
+      class="absolute top-full left-0 sm:left-1/2 sm:-translate-x-1/2 mt-1 z-50 w-72 max-w-[calc(100vw-2rem)] p-3 text-sm text-gray-700 bg-white border border-gray-200 rounded-lg shadow-lg normal-case tracking-normal font-normal"
     >
       <slot />
     </div>

--- a/src/components/PaginatedTable.vue
+++ b/src/components/PaginatedTable.vue
@@ -21,7 +21,7 @@ const props = withDefaults(
     empty: false,
     page: 0,
     totalPages: 1,
-    tableLayout: 'fixed',
+    tableLayout: 'auto',
   },
 )
 

--- a/src/components/PaginatedTable.vue
+++ b/src/components/PaginatedTable.vue
@@ -75,7 +75,7 @@ function nextPage() {
     </div>
 
     <!-- Pagination -->
-    <div v-if="props.totalPages > 1" class="flex items-center justify-between mt-4">
+    <div v-if="props.totalPages > 1" class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mt-4">
       <span class="text-sm text-gray-600">
         {{ t('common.pagination', { page: props.page + 1, totalPages: props.totalPages }) }}
       </span>
@@ -85,16 +85,16 @@ function nextPage() {
           class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           @click="previousPage"
         >
-          <ChevronLeftIcon class="h-4 w-4 mr-1" />
-          {{ t('common.previous') }}
+          <ChevronLeftIcon class="h-4 w-4 sm:mr-1" />
+          <span class="hidden sm:inline">{{ t('common.previous') }}</span>
         </button>
         <button
           :disabled="props.page >= props.totalPages - 1"
           class="inline-flex items-center px-3 py-1.5 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
           @click="nextPage"
         >
-          {{ t('common.next') }}
-          <ChevronRightIcon class="h-4 w-4 ml-1" />
+          <span class="hidden sm:inline">{{ t('common.next') }}</span>
+          <ChevronRightIcon class="h-4 w-4 sm:ml-1" />
         </button>
       </div>
     </div>

--- a/src/components/layout/AdminLayout.vue
+++ b/src/components/layout/AdminLayout.vue
@@ -1,14 +1,41 @@
 <script lang='ts' setup>
+
+import { useI18n } from 'vue-i18n'
+import { Bars3Icon } from '@heroicons/vue/20/solid'
 import SidebarNav from '@/components/layout/SidebarNav.vue'
 import BreadcrumbNav from '@/components/layout/BreadcrumbNav.vue'
+import { useSidebar } from '@/composables/useSidebar'
+
+const { t } = useI18n()
+const { sidebarOpen, toggleSidebar, closeSidebar } = useSidebar()
 </script>
 
 <template>
   <div class='flex h-screen'>
-    <SidebarNav />
-    <div class='flex-1 flex flex-col min-h-0'>
+    <!-- Backdrop (mobile/tablet only) -->
+    <div
+      v-if='sidebarOpen'
+      class='fixed inset-0 bg-black/50 z-40 lg:hidden'
+      @click='closeSidebar'
+    />
+
+    <!-- Sidebar -->
+    <SidebarNav
+      class='fixed inset-y-0 left-0 z-50 w-64 transition-transform duration-300 lg:relative lg:translate-x-0'
+      :class='sidebarOpen ? "translate-x-0" : "-translate-x-full"'
+    />
+
+    <!-- Main content -->
+    <div class='flex-1 flex flex-col min-h-0 min-w-0'>
+      <!-- Mobile header -->
+      <div class='h-14 shrink-0 flex items-center px-4 border-b border-gray-200 bg-white lg:hidden'>
+        <button :title='t("nav.openMenu")' @click='toggleSidebar'>
+          <Bars3Icon class='h-6 w-6 text-gray-600' />
+        </button>
+        <span class='ml-3 text-lg font-semibold text-gray-900'>SympAuthy Admin</span>
+      </div>
       <BreadcrumbNav />
-      <main class='flex-1 overflow-y-auto p-6'>
+      <main class='flex-1 overflow-y-auto p-4 lg:p-6'>
         <slot />
       </main>
     </div>

--- a/src/components/layout/BreadcrumbNav.vue
+++ b/src/components/layout/BreadcrumbNav.vue
@@ -57,7 +57,7 @@ const breadcrumbs = computed<BreadcrumbItem[]>(() => {
 </script>
 
 <template>
-  <nav v-if="breadcrumbs.length > 0" class="h-14 shrink-0 flex items-center border-b border-gray-200 bg-white px-6">
+  <nav v-if="breadcrumbs.length > 0" class="h-14 shrink-0 flex items-center border-b border-gray-200 bg-white px-4 lg:px-6">
     <ol class="flex items-center gap-2">
       <li v-for="(item, index) in breadcrumbs" :key="index" class="flex items-center gap-2">
         <ChevronRightIcon v-if="index > 0" class="h-4 w-4 text-gray-400 shrink-0" />

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -1,10 +1,12 @@
 <script lang="ts" setup>
 import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/useAuthStore'
-import { ArrowRightStartOnRectangleIcon } from '@heroicons/vue/24/outline'
+import { ArrowRightStartOnRectangleIcon, XMarkIcon } from '@heroicons/vue/20/solid'
+import { useSidebar } from '@/composables/useSidebar'
 
 const { t } = useI18n()
 const authStore = useAuthStore()
+const { closeSidebar } = useSidebar()
 
 async function logout() {
   await authStore.signout()
@@ -12,9 +14,12 @@ async function logout() {
 </script>
 
 <template>
-  <nav class="flex flex-col w-64 min-h-screen bg-gray-800 text-white">
-    <div class="h-14 flex items-center px-4 text-lg font-semibold border-b border-gray-700">
-      SympAuthy Admin
+  <nav class="flex flex-col h-full bg-gray-800 text-white">
+    <div class="h-14 flex items-center justify-between px-4 text-lg font-semibold border-b border-gray-700">
+      <span>SympAuthy Admin</span>
+      <button :title="t('nav.closeMenu')" class="lg:hidden text-gray-400 hover:text-white" @click="closeSidebar">
+        <XMarkIcon class="h-5 w-5" />
+      </button>
     </div>
     <ul class="flex flex-col mt-2 flex-1">
       <li>

--- a/src/composables/useSidebar.ts
+++ b/src/composables/useSidebar.ts
@@ -1,0 +1,34 @@
+import { ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
+
+const sidebarOpen = ref(false)
+
+export function useSidebar() {
+  const route = useRoute()
+
+  watch(
+    () => route.fullPath,
+    () => {
+      sidebarOpen.value = false
+    },
+  )
+
+  function openSidebar() {
+    sidebarOpen.value = true
+  }
+
+  function closeSidebar() {
+    sidebarOpen.value = false
+  }
+
+  function toggleSidebar() {
+    sidebarOpen.value = !sidebarOpen.value
+  }
+
+  return {
+    sidebarOpen,
+    openSidebar,
+    closeSidebar,
+    toggleSidebar,
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,7 +36,9 @@
     "claims": "Claims",
     "scopes": "Scopes",
     "configuration": "Configuration",
-    "sessions": "Sessions"
+    "sessions": "Sessions",
+    "openMenu": "Open menu",
+    "closeMenu": "Close menu"
   },
   "client": {
     "type": {

--- a/src/pages/ClaimsPage.vue
+++ b/src/pages/ClaimsPage.vue
@@ -23,7 +23,6 @@ onMounted(async () => {
       :empty="claimStore.claims.length === 0"
       :page="claimStore.page"
       :total-pages="claimStore.totalPages"
-      table-layout="auto"
       @page-change="claimStore.fetchClaims"
     >
       <template #header>

--- a/src/pages/ClaimsPage.vue
+++ b/src/pages/ClaimsPage.vue
@@ -50,7 +50,7 @@ onMounted(async () => {
               {{ t('pages.claims.disabled') }}
             </Tag>
           </td>
-          <td class="px-6 py-4 text-sm font-medium text-gray-900 min-w-40 max-w-xs truncate">
+          <td class="px-6 py-4 text-sm font-medium text-gray-900 truncate">
             {{ claim.id }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -22,23 +22,24 @@ onMounted(async () => {
       :empty="clientStore.clients.length === 0"
       :page="clientStore.page"
       :total-pages="clientStore.totalPages"
+      table-layout="auto"
       @page-change="clientStore.fetchClients"
     >
       <template #header>
-        <th class="w-[10%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.clientId') }}
         </th>
-        <th class="w-[10%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.type') }}
           <ClientTypeHelpTooltip />
         </th>
-        <th class="w-[25%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.allowedScopes') }}
         </th>
-        <th class="w-[25%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.defaultScopes') }}
         </th>
-        <th class="w-[30%] px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.clients.redirectUris') }}
         </th>
       </template>

--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -26,10 +26,10 @@ onMounted(async () => {
       @page-change="clientStore.fetchClients"
     >
       <template #header>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.clients.clientId') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.clients.type') }}
           <ClientTypeHelpTooltip />
         </th>
@@ -73,7 +73,7 @@ onMounted(async () => {
             </Tag>
           </td>
           <td class="px-6 py-4 text-sm text-gray-500">
-            <div v-for="uri in client.allowed_redirect_uris" :key="uri" class="truncate max-w-xs">
+            <div v-for="uri in client.allowed_redirect_uris" :key="uri" class="truncate">
               {{ uri }}
             </div>
           </td>

--- a/src/pages/ClientsPage.vue
+++ b/src/pages/ClientsPage.vue
@@ -22,7 +22,7 @@ onMounted(async () => {
       :empty="clientStore.clients.length === 0"
       :page="clientStore.page"
       :total-pages="clientStore.totalPages"
-      table-layout="auto"
+
       @page-change="clientStore.fetchClients"
     >
       <template #header>

--- a/src/pages/ScopesPage.vue
+++ b/src/pages/ScopesPage.vue
@@ -81,7 +81,6 @@ onMounted(async () => {
       :empty="scopeStore.scopes.length === 0"
       :page="scopeStore.page"
       :total-pages="scopeStore.totalPages"
-      table-layout="auto"
       @page-change="scopeStore.fetchScopes"
     >
       <template #header>

--- a/src/pages/ScopesPage.vue
+++ b/src/pages/ScopesPage.vue
@@ -111,7 +111,7 @@ onMounted(async () => {
               {{ t('pages.scopes.disabled') }}
             </Tag>
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+          <td class="px-6 py-4 text-sm font-medium text-gray-900 truncate">
             {{ scope.id }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">
@@ -122,7 +122,7 @@ onMounted(async () => {
           <td class="px-6 py-4 whitespace-nowrap text-sm">
             <OriginTag :origin="scope.origin" />
           </td>
-          <td class="px-6 py-4 text-sm text-gray-500">
+          <td class="px-6 py-4 text-sm text-gray-500 truncate">
             <span v-if="scope.claims && scope.claims.length > 0">
               {{ scope.claims.join(', ') }}
             </span>

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -85,7 +85,7 @@ onMounted(async () => {
       :empty="userStore.users.length === 0"
       :page="userStore.page"
       :total-pages="userStore.totalPages"
-      table-layout="auto"
+
       @page-change="userStore.fetchUsers"
     >
       <template #header>

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -107,14 +107,14 @@ onMounted(async () => {
           @sort="userStore.toggleSort"
         />
         <SortableHeader
-          class="w-0 whitespace-nowrap"
+          class="w-0 whitespace-nowrap hidden sm:table-cell"
           :label="t('pages.users.createdAt')"
           field="created_at"
           :current-sort="userStore.sortField"
           :current-order="userStore.sortOrder"
           @sort="userStore.toggleSort"
         />
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.users.actions') }}
         </th>
       </template>
@@ -132,11 +132,11 @@ onMounted(async () => {
           <td
             v-for="claim in enabledClaims"
             :key="claim.id"
-            class="px-6 py-4 whitespace-nowrap text-sm text-gray-500"
+            class="px-6 py-4 text-sm text-gray-500 truncate"
           >
             {{ user.claims?.[claim.id] ?? '' }}
           </td>
-          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 hidden sm:table-cell">
             {{ formatDate(user.created_at) }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/src/pages/UsersPage.vue
+++ b/src/pages/UsersPage.vue
@@ -114,7 +114,7 @@ onMounted(async () => {
           :current-order="userStore.sortOrder"
           @sort="userStore.toggleSort"
         />
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.users.actions') }}
         </th>
       </template>
@@ -147,7 +147,7 @@ onMounted(async () => {
               >
                 <span class="inline-flex items-center gap-1.5">
                   <EyeIcon class="size-4 shrink-0" />
-                  {{ t('pages.users.view') }}
+                  <span class="hidden sm:inline">{{ t('pages.users.view') }}</span>
                 </span>
               </CommonButton>
               <CommonButton
@@ -156,7 +156,7 @@ onMounted(async () => {
               >
                 <span class="inline-flex items-center gap-1.5">
                   <ArrowRightStartOnRectangleIcon class="size-4 shrink-0" />
-                  {{ t('pages.users.logout') }}
+                  <span class="hidden sm:inline">{{ t('pages.users.logout') }}</span>
                 </span>
               </CommonButton>
             </div>

--- a/src/pages/userdetail/UserClaimsPanel.vue
+++ b/src/pages/userdetail/UserClaimsPanel.vue
@@ -60,10 +60,10 @@ function formatDate(dateStr: string | null | undefined): string {
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.claimTags') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.collectedAt') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.verifiedAt') }}
         </th>
       </template>
@@ -73,7 +73,7 @@ function formatDate(dateStr: string | null | undefined): string {
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
             {{ claim.claim_id }}
           </td>
-          <td class="px-6 py-4 text-sm text-gray-500 truncate max-w-xs">
+          <td class="px-6 py-4 text-sm text-gray-500 truncate max-w-[200px] sm:max-w-xs">
             {{ claim.value ?? '—' }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/src/pages/userdetail/UserClaimsPanel.vue
+++ b/src/pages/userdetail/UserClaimsPanel.vue
@@ -48,7 +48,7 @@ function formatDate(dateStr: string | null | undefined): string {
       @page-change="(page: number) => store.fetchClaims(userId, page)"
     >
       <template #header>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.claim') }}
         </th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -60,10 +60,10 @@ function formatDate(dateStr: string | null | undefined): string {
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.claimTags') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.collectedAt') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.verifiedAt') }}
         </th>
       </template>
@@ -73,7 +73,7 @@ function formatDate(dateStr: string | null | undefined): string {
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
             {{ claim.claim_id }}
           </td>
-          <td class="px-6 py-4 text-sm text-gray-500 truncate max-w-[200px] sm:max-w-xs">
+          <td class="px-6 py-4 text-sm text-gray-500 truncate">
             {{ claim.value ?? '—' }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">

--- a/src/pages/userdetail/UserClaimsPanel.vue
+++ b/src/pages/userdetail/UserClaimsPanel.vue
@@ -44,7 +44,7 @@ function formatDate(dateStr: string | null | undefined): string {
       :empty="store.claims.length === 0"
       :page="store.claimsPage"
       :total-pages="store.claimsTotalPages"
-      table-layout="auto"
+
       @page-change="(page: number) => store.fetchClaims(userId, page)"
     >
       <template #header>

--- a/src/pages/userdetail/UserConsentsPanel.vue
+++ b/src/pages/userdetail/UserConsentsPanel.vue
@@ -49,7 +49,7 @@ const store = useUserConsentStore()
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.scopes') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[100px]">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.actions') }}
         </th>
       </template>

--- a/src/pages/userdetail/UserConsentsPanel.vue
+++ b/src/pages/userdetail/UserConsentsPanel.vue
@@ -43,13 +43,13 @@ const store = useUserConsentStore()
       @page-change="(page: number) => store.fetchConsents(userId, page)"
     >
       <template #header>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.client') }}
         </th>
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.scopes') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.actions') }}
         </th>
       </template>

--- a/src/pages/userdetail/UserMfaPanel.vue
+++ b/src/pages/userdetail/UserMfaPanel.vue
@@ -69,13 +69,14 @@ function cancelRevoke() {
       @page-change="(page: number) => store.fetchMfaMethods(userId, page)"
     >
       <template #header>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.mfaType') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3"></th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.registeredAt') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
           {{ t('pages.userDetail.actions') }}
         </th>
       </template>
@@ -85,6 +86,7 @@ function cancelRevoke() {
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
             {{ method.type }}
           </td>
+          <td></td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
             {{ formatDate(method.registered_at) }}
           </td>

--- a/src/pages/userdetail/UserMfaPanel.vue
+++ b/src/pages/userdetail/UserMfaPanel.vue
@@ -15,6 +15,10 @@ const props = defineProps<{
 const { t } = useI18n()
 const store = useUserMfaStore()
 
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString()
+}
+
 const revokeDialogOpen = ref(false)
 const revokeTargetMfaId = ref<string | null>(null)
 
@@ -71,7 +75,7 @@ function cancelRevoke() {
         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.registeredAt') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[100px]">
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
           {{ t('pages.userDetail.actions') }}
         </th>
       </template>
@@ -82,7 +86,7 @@ function cancelRevoke() {
             {{ method.type }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-            {{ method.registered_at }}
+            {{ formatDate(method.registered_at) }}
           </td>
           <td class="px-6 py-4 whitespace-nowrap text-sm">
             <CommonButton

--- a/src/pages/userdetail/UserSummaryPanel.vue
+++ b/src/pages/userdetail/UserSummaryPanel.vue
@@ -38,7 +38,7 @@ function formatDate(dateStr: string): string {
 </script>
 
 <template>
-  <div class="bg-white rounded-lg border border-gray-200 p-6">
+  <div class="bg-white rounded-lg border border-gray-200 p-4 sm:p-6">
     <div class="flex items-start justify-between gap-4">
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 flex-1 min-w-0">
         <div class="min-w-0">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -47,6 +47,15 @@ body {
     }
 }
 
+/** Responsive table padding **/
+@media (max-width: 639px) {
+    .overflow-x-auto td,
+    .overflow-x-auto th {
+        padding-left: 0.75rem;
+        padding-right: 0.75rem;
+    }
+}
+
 /** Link **/
 @layer components {
     .a {


### PR DESCRIPTION
## Summary

- Implement mobile-first responsive layout with slide-over sidebar drawer on phones/tablets (`lg:` breakpoint for permanent sidebar)
- Add `useSidebar` composable for shared drawer state with auto-close on navigation
- Adapt all data tables with consistent column sizing: shrink-wrap for status/dates/actions, fill+truncate for content columns
- Hide secondary columns (Created At) on phones, show icon-only action buttons
- Reduce padding, stack filters/pagination vertically on small screens
- Default `PaginatedTable` to `table-auto` and document conventions in CLAUDE.md

## Test plan

- [x] Verify at phone (~375px): hamburger drawer, icon-only buttons, hidden Created At, horizontal table scroll
- [x] Verify at tablet (~768px): drawer behavior, filters side-by-side
- [x] Verify at desktop (~1440px): permanent sidebar, full table layout, all columns visible
- [x] Test drawer auto-close on navigation
- [x] Test backdrop click closes drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)