### PR TITLE
Add provider links panel to user detail page

### DIFF
--- a/src/client/api/UserProviderLinkApi.ts
+++ b/src/client/api/UserProviderLinkApi.ts
@@ -1,0 +1,33 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type UserProviderLinkListResource,
+  userProviderLinkListResourceSchema,
+} from '@/client/model/UserProviderLinkListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export class UserProviderLinkApi extends AbstractApi {
+  async listProviderLinks(
+    userId: string,
+    page: number = 0,
+    size: number = 20,
+  ): Promise<SuccessApiResponse<UserProviderLinkListResource> | ErrorApiResponse> {
+    return this.get<UserProviderLinkListResource>({
+      path: `/api/v1/admin/users/${userId}/providers`,
+      params: {
+        page: page.toString(),
+        size: size.toString(),
+      },
+      schema: userProviderLinkListResourceSchema,
+    })
+  }
+
+  async unlinkProvider(
+    userId: string,
+    providerId: string,
+  ): Promise<SuccessApiResponse<void> | ErrorApiResponse> {
+    return this.delete({
+      path: `/api/v1/admin/users/${userId}/providers/${providerId}`,
+    })
+  }
+}

--- a/src/client/model/UserProviderLinkListResource.ts
+++ b/src/client/model/UserProviderLinkListResource.ts
@@ -1,0 +1,33 @@
+import type { JSONSchemaType } from 'ajv'
+import {
+  type UserProviderLinkResource,
+  userProviderLinkResourceSchema,
+} from '@/client/model/UserProviderLinkResource'
+
+export type UserProviderLinkListResource = {
+  providers: UserProviderLinkResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const userProviderLinkListResourceSchema: JSONSchemaType<UserProviderLinkListResource> = {
+  type: 'object',
+  properties: {
+    providers: {
+      type: 'array',
+      items: { ...userProviderLinkResourceSchema },
+    },
+    page: {
+      type: 'number',
+    },
+    size: {
+      type: 'number',
+    },
+    total: {
+      type: 'number',
+    },
+  },
+  required: ['providers', 'page', 'size', 'total'],
+  additionalProperties: true,
+}

--- a/src/client/model/UserProviderLinkResource.ts
+++ b/src/client/model/UserProviderLinkResource.ts
@@ -1,0 +1,24 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type UserProviderLinkResource = {
+  provider_id: string
+  subject: string
+  linked_at: string
+}
+
+export const userProviderLinkResourceSchema: JSONSchemaType<UserProviderLinkResource> = {
+  type: 'object',
+  properties: {
+    provider_id: {
+      type: 'string',
+    },
+    subject: {
+      type: 'string',
+    },
+    linked_at: {
+      type: 'string',
+    },
+  },
+  required: ['provider_id', 'subject', 'linked_at'],
+  additionalProperties: true,
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -120,7 +120,18 @@
       "registeredAt": "Registered at",
       "noMfaMethods": "No MFA methods registered.",
       "revokeMfaTitle": "Revoke MFA Method",
-      "revokeMfaDescription": "This will remove the MFA method from the user's account. They will need to set it up again."
+      "revokeMfaDescription": "This will remove the MFA method from the user's account. They will need to set it up again.",
+      "providerLinks": "Provider Links",
+      "providerLinksHelp": "External identity providers linked to this user's account. Unlinking a provider will prevent the user from signing in with it. See {link} for details.",
+      "providerLinksHelpLinkText": "providers documentation",
+      "providerLinksHelpLinkUrl": "https://sympauthy.github.io/functional/authentication.html#providers",
+      "provider": "Provider",
+      "subject": "Subject",
+      "linkedAt": "Linked at",
+      "unlink": "Unlink",
+      "noProviderLinks": "No provider links found.",
+      "unlinkProviderTitle": "Unlink Provider",
+      "unlinkProviderDescription": "This will remove the link between this user and the identity provider. The user will no longer be able to sign in with this provider."
     },
     "scopes": {
       "title": "Scopes",

--- a/src/pages/userdetail/UserDetailPage.vue
+++ b/src/pages/userdetail/UserDetailPage.vue
@@ -5,11 +5,13 @@ import { useI18n } from 'vue-i18n'
 import { useUserDetailStore } from '@/stores/useUserDetailStore'
 import { useUserConsentStore } from '@/stores/useUserConsentStore'
 import { useUserMfaStore } from '@/stores/useUserMfaStore'
+import { useUserProviderLinkStore } from '@/stores/useUserProviderLinkStore'
 import { useBreadcrumb } from '@/composables/useBreadcrumb'
 import UserSummaryPanel from '@/pages/userdetail/UserSummaryPanel.vue'
 import UserClaimsPanel from '@/pages/userdetail/UserClaimsPanel.vue'
 import UserConsentsPanel from '@/pages/userdetail/UserConsentsPanel.vue'
 import UserMfaPanel from '@/pages/userdetail/UserMfaPanel.vue'
+import UserProvidersPanel from '@/pages/userdetail/UserProvidersPanel.vue'
 import LogoutDialog from '@/components/LogoutDialog.vue'
 import CommonSpinner from '@/components/CommonSpinner.vue'
 import CommonAlert from '@/components/CommonAlert.vue'
@@ -19,6 +21,7 @@ const { t } = useI18n()
 const store = useUserDetailStore()
 const consentStore = useUserConsentStore()
 const mfaStore = useUserMfaStore()
+const providerLinkStore = useUserProviderLinkStore()
 const { setLabel } = useBreadcrumb()
 
 const userId = computed(() => route.params.userId as string)
@@ -28,11 +31,13 @@ onMounted(async () => {
   store.$reset()
   consentStore.$reset()
   mfaStore.$reset()
+  providerLinkStore.$reset()
   await Promise.all([
     store.fetchUser(userId.value),
     store.fetchClaims(userId.value),
     consentStore.fetchConsents(userId.value),
     mfaStore.fetchMfaMethods(userId.value),
+    providerLinkStore.fetchProviderLinks(userId.value),
   ])
   if (store.user) {
     const identifier = store.user.identifier_claims
@@ -65,6 +70,7 @@ onMounted(async () => {
       <UserClaimsPanel :user-id="userId" />
       <UserConsentsPanel :user-id="userId" />
       <UserMfaPanel :user-id="userId" />
+      <UserProvidersPanel :user-id="userId" />
     </div>
 
     <LogoutDialog

--- a/src/pages/userdetail/UserProvidersPanel.vue
+++ b/src/pages/userdetail/UserProvidersPanel.vue
@@ -1,0 +1,127 @@
+<script lang="ts" setup>
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useUserProviderLinkStore } from '@/stores/useUserProviderLinkStore'
+import HelpTooltip from '@/components/HelpTooltip.vue'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+import CommonButton from '@/components/CommonButton.vue'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import { dangerColoredButton } from '@/styles/ButtonStyle'
+
+const props = defineProps<{
+  userId: string
+}>()
+
+const { t } = useI18n()
+const store = useUserProviderLinkStore()
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString()
+}
+
+const unlinkDialogOpen = ref(false)
+const unlinkTargetProviderId = ref<string | null>(null)
+
+function openUnlinkDialog(providerId: string) {
+  unlinkTargetProviderId.value = providerId
+  unlinkDialogOpen.value = true
+}
+
+async function confirmUnlink() {
+  if (unlinkTargetProviderId.value) {
+    await store.unlinkProvider(props.userId, unlinkTargetProviderId.value)
+  }
+  unlinkDialogOpen.value = false
+  unlinkTargetProviderId.value = null
+}
+
+function cancelUnlink() {
+  unlinkDialogOpen.value = false
+  unlinkTargetProviderId.value = null
+}
+</script>
+
+<template>
+  <div>
+    <h2 class="text-lg font-semibold text-gray-900 mb-4">
+      {{ t('pages.userDetail.providerLinks') }}
+      <HelpTooltip>
+        <i18n-t keypath="pages.userDetail.providerLinksHelp" tag="p">
+          <template #link>
+            <a
+              :href="t('pages.userDetail.providerLinksHelpLinkUrl')"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-blue-600 hover:underline"
+            >
+              {{ t('pages.userDetail.providerLinksHelpLinkText') }}
+            </a>
+          </template>
+        </i18n-t>
+      </HelpTooltip>
+    </h2>
+    <PaginatedTable
+      :loading="store.providerLinksLoading"
+      :error="store.providerLinksError"
+      :empty="store.providerLinks.length === 0"
+      :page="store.providerLinksPage"
+      :total-pages="store.providerLinksTotalPages"
+      @page-change="(page: number) => store.fetchProviderLinks(userId, page)"
+    >
+      <template #header>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
+          {{ t('pages.userDetail.provider') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+          {{ t('pages.userDetail.subject') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap hidden sm:table-cell">
+          {{ t('pages.userDetail.linkedAt') }}
+        </th>
+        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap">
+          {{ t('pages.userDetail.actions') }}
+        </th>
+      </template>
+
+      <template #rows>
+        <tr v-for="link in store.providerLinks" :key="link.provider_id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {{ link.provider_id }}
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-900 truncate">
+            {{ link.subject }}
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 hidden sm:table-cell">
+            {{ formatDate(link.linked_at) }}
+          </td>
+          <td class="px-6 py-4 whitespace-nowrap text-sm">
+            <CommonButton
+              :button-style="dangerColoredButton"
+              @click="openUnlinkDialog(link.provider_id)"
+            >
+              {{ t('pages.userDetail.unlink') }}
+            </CommonButton>
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.userDetail.noProviderLinks') }}</p>
+      </template>
+    </PaginatedTable>
+
+    <ConfirmDialog
+      :open="unlinkDialogOpen"
+      :confirm-label="t('pages.userDetail.unlink')"
+      @confirm="confirmUnlink"
+      @cancel="cancelUnlink"
+    >
+      <template #title>
+        {{ t('pages.userDetail.unlinkProviderTitle') }}
+      </template>
+      <p class="text-sm text-gray-600">
+        {{ t('pages.userDetail.unlinkProviderDescription') }}
+      </p>
+    </ConfirmDialog>
+  </div>
+</template>

--- a/src/stores/useUserProviderLinkStore.ts
+++ b/src/stores/useUserProviderLinkStore.ts
@@ -1,0 +1,77 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { UserProviderLinkApi } from '@/client/api/UserProviderLinkApi'
+import type { UserProviderLinkResource } from '@/client/model/UserProviderLinkResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useUserProviderLinkStore = defineStore('userProviderLink', () => {
+  const providerLinkApi = new UserProviderLinkApi()
+
+  const providerLinks = ref<UserProviderLinkResource[]>([])
+  const providerLinksLoading = ref(false)
+  const providerLinksError = ref<string | null>(null)
+  const providerLinksPage = ref(0)
+  const providerLinksSize = ref(20)
+  const providerLinksTotal = ref(0)
+
+  const providerLinksTotalPages = computed(() =>
+    Math.ceil(providerLinksTotal.value / providerLinksSize.value),
+  )
+
+  async function fetchProviderLinks(
+    userId: string,
+    requestedPage: number = 0,
+  ): Promise<void> {
+    providerLinksLoading.value = true
+    providerLinksError.value = null
+
+    const response = await providerLinkApi.listProviderLinks(
+      userId,
+      requestedPage,
+      providerLinksSize.value,
+    )
+
+    if (isSuccess(response)) {
+      providerLinks.value = response.content.providers
+      providerLinksPage.value = response.content.page
+      providerLinksTotal.value = response.content.total
+    } else {
+      providerLinksError.value = getErrorMessage(response as ErrorApiResponse)
+      providerLinks.value = []
+    }
+
+    providerLinksLoading.value = false
+  }
+
+  async function unlinkProvider(userId: string, providerId: string): Promise<void> {
+    const response = await providerLinkApi.unlinkProvider(userId, providerId)
+
+    if (isSuccess(response)) {
+      await fetchProviderLinks(userId, providerLinksPage.value)
+    } else {
+      providerLinksError.value = getErrorMessage(response as ErrorApiResponse)
+    }
+  }
+
+  function $reset() {
+    providerLinks.value = []
+    providerLinksLoading.value = false
+    providerLinksError.value = null
+    providerLinksPage.value = 0
+    providerLinksTotal.value = 0
+  }
+
+  return {
+    providerLinks,
+    providerLinksLoading,
+    providerLinksError,
+    providerLinksPage,
+    providerLinksSize,
+    providerLinksTotal,
+    providerLinksTotalPages,
+    fetchProviderLinks,
+    unlinkProvider,
+    $reset,
+  }
+})


### PR DESCRIPTION
## Summary

- Add a **Provider Links** section to the user detail page showing external identity providers (e.g. Google, Discord) linked to the user
- Support pagination and unlinking with a confirmation dialog
- Uses the new `GET /api/v1/admin/users/{user_id}/providers` and `DELETE /api/v1/admin/users/{user_id}/providers/{provider_id}` endpoints from sympauthy/sympauthy#166

## Test plan

- [ ] Navigate to a user detail page and verify the Provider Links panel renders (empty state if backend not available)
- [ ] With the backend running, verify provider links are listed with provider ID, subject, and linked-at date
- [ ] Verify pagination works when there are more than 20 links
- [ ] Click "Unlink" and verify the confirmation dialog appears
- [ ] Confirm unlink and verify the provider is removed from the list
- [ ] Verify responsive behavior: "Linked at" column hidden on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)