### PR TITLE
Add DPoP support for OIDC token requests

### DIFF
--- a/src/auth/AuthService.ts
+++ b/src/auth/AuthService.ts
@@ -2,7 +2,8 @@ import {
   UserManager,
   type User,
   type UserManagerSettings,
-  WebStorageStateStore
+  WebStorageStateStore,
+  IndexedDbDPoPStore
 } from 'oidc-client-ts'
 
 export type AuthUser = {
@@ -35,7 +36,11 @@ function makeUserManagerSettings(): UserManagerSettings {
     scope: import.meta.env.VITE_OIDC_SCOPE,
     response_type: 'code',
     automaticSilentRenew: true,
-    userStore: new WebStorageStateStore({ store: window.localStorage })
+    userStore: new WebStorageStateStore({ store: window.localStorage }),
+    dpop: {
+      bind_authorization_code: true,
+      store: new IndexedDbDPoPStore()
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Enable DPoP (RFC 9449) in `oidc-client-ts` UserManager configuration
- Key pair persisted in IndexedDB via `IndexedDbDPoPStore` for consistent key across token refreshes
- Authorization code bound to DPoP key via `dpop_jkt` parameter
- Matches server-side DPoP implementation (sympauthy/sympauthy#178)

## Details
`oidc-client-ts` v3.4.1 handles DPoP automatically once enabled — proof JWTs are generated for all token endpoint requests (code exchange + refresh), and `use_dpop_nonce` errors are retried transparently.

No changes to `AbstractApi` or API calls: the resource server does not validate DPoP proofs yet, so requests continue using `Authorization: Bearer`. This is fully backward-compatible — when the server doesn't support DPoP, it ignores the `DPoP` header and issues a standard Bearer token.

## Test plan
- [ ] `npm run build` passes (type-check + production build)
- [ ] OIDC login flow completes successfully
- [ ] Token endpoint request includes a `DPoP` header (check DevTools Network tab)
- [ ] API calls work (Bearer token accepted by resource server)
- [ ] Silent token refresh succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)