### PR TITLE
Add audiences list page

### DIFF
--- a/src/client/api/AudienceApi.ts
+++ b/src/client/api/AudienceApi.ts
@@ -1,0 +1,23 @@
+import { AbstractApi } from '@/client/AbstractApi'
+import {
+  type AudienceListResource,
+  audienceListResourceSchema
+} from '@/client/model/AudienceListResource'
+import type { SuccessApiResponse } from '@/client/SuccessApiResponse'
+import type { ErrorApiResponse } from '@/client/ErrorApiResponse'
+
+export class AudienceApi extends AbstractApi {
+  async listAudiences(
+    page: number = 0,
+    size: number = 20
+  ): Promise<SuccessApiResponse<AudienceListResource> | ErrorApiResponse> {
+    return this.get<AudienceListResource>({
+      path: '/api/v1/admin/audiences',
+      params: {
+        page: page.toString(),
+        size: size.toString()
+      },
+      schema: audienceListResourceSchema
+    })
+  }
+}

--- a/src/client/model/AudienceListResource.ts
+++ b/src/client/model/AudienceListResource.ts
@@ -1,0 +1,30 @@
+import type { JSONSchemaType } from 'ajv'
+import { type AudienceResource, audienceResourceSchema } from '@/client/model/AudienceResource'
+
+export type AudienceListResource = {
+  audiences: AudienceResource[]
+  page: number
+  size: number
+  total: number
+}
+
+export const audienceListResourceSchema: JSONSchemaType<AudienceListResource> = {
+  type: 'object',
+  properties: {
+    audiences: {
+      type: 'array',
+      items: { ...audienceResourceSchema }
+    },
+    page: {
+      type: 'number'
+    },
+    size: {
+      type: 'number'
+    },
+    total: {
+      type: 'number'
+    }
+  },
+  required: ['audiences', 'page', 'size', 'total'],
+  additionalProperties: true
+}

--- a/src/client/model/AudienceResource.ts
+++ b/src/client/model/AudienceResource.ts
@@ -1,0 +1,20 @@
+import type { JSONSchemaType } from 'ajv'
+
+export type AudienceResource = {
+  audience_id: string
+  token_audience: string
+}
+
+export const audienceResourceSchema: JSONSchemaType<AudienceResource> = {
+  type: 'object',
+  properties: {
+    audience_id: {
+      type: 'string'
+    },
+    token_audience: {
+      type: 'string'
+    }
+  },
+  required: ['audience_id', 'token_audience'],
+  additionalProperties: true
+}

--- a/src/components/layout/SidebarNav.vue
+++ b/src/components/layout/SidebarNav.vue
@@ -78,6 +78,17 @@ async function logout() {
           {{ t('nav.scopes') }}
         </router-link>
       </li>
+      <li>
+        <router-link
+          to="/audiences"
+          :class="[
+            'block px-4 py-2 hover:bg-gray-700 transition-colors',
+            { 'bg-gray-900': isActive('/audiences') }
+          ]"
+        >
+          {{ t('nav.audiences') }}
+        </router-link>
+      </li>
       <!-- <li>
         <router-link to='/configuration' class='block px-4 py-2 hover:bg-gray-700 transition-colors' active-class='bg-gray-900'>
           {{ t('nav.configuration') }}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,6 +34,7 @@
     "clients": "Clients",
     "claims": "Claims",
     "scopes": "Scopes",
+    "audiences": "Audiences",
     "configuration": "Configuration",
     "sessions": "Sessions",
     "openMenu": "Open menu",
@@ -150,6 +151,12 @@
       "statusFilter": "status",
       "allStatuses": "all statuses",
       "empty": "No scopes found."
+    },
+    "audiences": {
+      "title": "Audiences",
+      "audienceId": "Audience ID",
+      "tokenAudience": "Token Audience",
+      "empty": "No audiences found."
     },
     "claims": {
       "title": "Claims",

--- a/src/pages/AudiencesPage.vue
+++ b/src/pages/AudiencesPage.vue
@@ -1,0 +1,54 @@
+<script lang="ts" setup>
+import { onMounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useAudienceStore } from '@/stores/useAudienceStore'
+import PaginatedTable from '@/components/PaginatedTable.vue'
+
+const { t } = useI18n()
+const audienceStore = useAudienceStore()
+
+onMounted(async () => {
+  await audienceStore.fetchAudiences()
+})
+</script>
+
+<template>
+  <div>
+    <PaginatedTable
+      :loading="audienceStore.loading"
+      :error="audienceStore.error"
+      :empty="audienceStore.audiences.length === 0"
+      :page="audienceStore.page"
+      :total-pages="audienceStore.totalPages"
+      @page-change="audienceStore.fetchAudiences"
+    >
+      <template #header>
+        <th
+          class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap"
+        >
+          {{ t('pages.audiences.audienceId') }}
+        </th>
+        <th
+          class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+        >
+          {{ t('pages.audiences.tokenAudience') }}
+        </th>
+      </template>
+
+      <template #rows>
+        <tr v-for="audience in audienceStore.audiences" :key="audience.audience_id">
+          <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+            {{ audience.audience_id }}
+          </td>
+          <td class="px-6 py-4 text-sm text-gray-500 truncate">
+            {{ audience.token_audience }}
+          </td>
+        </tr>
+      </template>
+
+      <template #empty>
+        <p class="text-gray-600">{{ t('pages.audiences.empty') }}</p>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import AudiencesPage from '@/pages/AudiencesPage.vue'
 import ClientsPage from '@/pages/ClientsPage.vue'
 import ClaimsPage from '@/pages/ClaimsPage.vue'
 import ScopesPage from '@/pages/ScopesPage.vue'
@@ -65,6 +66,12 @@ export function makeRouter() {
         name: 'scopes',
         component: ScopesPage,
         meta: { requiresAuth: true, breadcrumb: { label: 'nav.scopes' } }
+      },
+      {
+        path: '/audiences',
+        name: 'audiences',
+        component: AudiencesPage,
+        meta: { requiresAuth: true, breadcrumb: { label: 'nav.audiences' } }
       }
     ]
   })

--- a/src/stores/useAudienceStore.ts
+++ b/src/stores/useAudienceStore.ts
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+import { AudienceApi } from '@/client/api/AudienceApi'
+import type { AudienceResource } from '@/client/model/AudienceResource'
+import { isSuccess } from '@/client/SuccessApiResponse'
+import { type ErrorApiResponse, getErrorMessage } from '@/client/ErrorApiResponse'
+
+export const useAudienceStore = defineStore('audiences', () => {
+  const api = new AudienceApi()
+
+  const audiences = ref<AudienceResource[]>([])
+  const loading = ref(false)
+  const error = ref<string | null>(null)
+  const page = ref(0)
+  const size = ref(20)
+  const total = ref(0)
+
+  const totalPages = computed(() => Math.ceil(total.value / size.value))
+
+  async function fetchAudiences(requestedPage: number = 0): Promise<void> {
+    loading.value = true
+    error.value = null
+
+    const response = await api.listAudiences(requestedPage, size.value)
+
+    if (isSuccess(response)) {
+      audiences.value = response.content.audiences
+      page.value = response.content.page
+      total.value = response.content.total
+    } else {
+      error.value = getErrorMessage(response as ErrorApiResponse)
+      audiences.value = []
+    }
+
+    loading.value = false
+  }
+
+  return {
+    audiences,
+    loading,
+    error,
+    page,
+    size,
+    total,
+    totalPages,
+    fetchAudiences
+  }
+})


### PR DESCRIPTION
## Summary
- Add a paginated audiences list page at `/audiences` connected to the new admin audiences API (`GET /api/v1/admin/audiences` from sympauthy/sympauthy#226)
- Add "Audiences" entry to the sidebar navigation after Scopes
- Follow existing patterns (model + AJV schema, API client, Pinia store, paginated table page)

## Test plan
- [ ] Navigate to `/audiences` and verify the page renders with the table
- [ ] Verify the sidebar highlights "Audiences" when on the page
- [ ] Verify pagination controls work when there are multiple pages of audiences
- [ ] Verify error state displays correctly if the backend is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)