### PR TITLE
Add registration mode and clients count to audience list

### DIFF
--- a/src/client/model/AudienceResource.ts
+++ b/src/client/model/AudienceResource.ts
@@ -3,6 +3,9 @@ import type { JSONSchemaType } from 'ajv'
 export type AudienceResource = {
   audience_id: string
   token_audience: string
+  sign_up_enabled: boolean
+  invitation_enabled: boolean
+  clients_count: number
 }
 
 export const audienceResourceSchema: JSONSchemaType<AudienceResource> = {
@@ -13,8 +16,39 @@ export const audienceResourceSchema: JSONSchemaType<AudienceResource> = {
     },
     token_audience: {
       type: 'string'
+    },
+    sign_up_enabled: {
+      type: 'boolean'
+    },
+    invitation_enabled: {
+      type: 'boolean'
+    },
+    clients_count: {
+      type: 'number'
     }
   },
-  required: ['audience_id', 'token_audience'],
+  required: [
+    'audience_id',
+    'token_audience',
+    'sign_up_enabled',
+    'invitation_enabled',
+    'clients_count'
+  ],
   additionalProperties: true
+}
+
+export function audienceRegistrationModeKey(audience: AudienceResource): string {
+  if (audience.sign_up_enabled && audience.invitation_enabled)
+    return 'common.audience.registrationMode.openInvitations'
+  if (audience.sign_up_enabled) return 'common.audience.registrationMode.open'
+  if (audience.invitation_enabled) return 'common.audience.registrationMode.invitationOnly'
+  return 'common.audience.registrationMode.closed'
+}
+
+export function audienceRegistrationModeColor(
+  audience: AudienceResource
+): 'green' | 'yellow' | 'red' {
+  if (audience.sign_up_enabled) return 'green'
+  if (audience.invitation_enabled) return 'yellow'
+  return 'red'
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -34,6 +34,15 @@
       "openid": "openid",
       "system": "system",
       "custom": "custom"
+    },
+    "audience": {
+      "registrationMode": {
+        "label": "Registration mode",
+        "open": "open",
+        "openInvitations": "open + invitations",
+        "invitationOnly": "invitation-only",
+        "closed": "closed"
+      }
     }
   },
   "nav": {
@@ -165,7 +174,7 @@
     "audiences": {
       "title": "Audiences",
       "audienceId": "Audience ID",
-      "tokenAudience": "Token Audience",
+      "clientsCount": "Clients",
       "empty": "No audiences found."
     },
     "invitations": {

--- a/src/pages/AudiencesPage.vue
+++ b/src/pages/AudiencesPage.vue
@@ -3,6 +3,11 @@ import { onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAudienceStore } from '@/stores/useAudienceStore'
 import PaginatedTable from '@/components/PaginatedTable.vue'
+import Tag from '@/components/Tag.vue'
+import {
+  audienceRegistrationModeKey,
+  audienceRegistrationModeColor
+} from '@/client/model/AudienceResource'
 
 const { t } = useI18n()
 const audienceStore = useAudienceStore()
@@ -24,12 +29,19 @@ onMounted(async () => {
     >
       <template #header>
         <th
-          class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap"
+          class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
         >
           {{ t('pages.audiences.audienceId') }}
         </th>
-        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-          {{ t('pages.audiences.tokenAudience') }}
+        <th
+          class="hidden sm:table-cell px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap"
+        >
+          {{ t('common.audience.registrationMode.label') }}
+        </th>
+        <th
+          class="hidden sm:table-cell px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-0 whitespace-nowrap"
+        >
+          {{ t('pages.audiences.clientsCount') }}
         </th>
       </template>
 
@@ -38,8 +50,13 @@ onMounted(async () => {
           <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
             {{ audience.audience_id }}
           </td>
-          <td class="px-6 py-4 text-sm text-gray-500 truncate">
-            {{ audience.token_audience }}
+          <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm">
+            <Tag :color="audienceRegistrationModeColor(audience)">
+              {{ t(audienceRegistrationModeKey(audience)) }}
+            </Tag>
+          </td>
+          <td class="hidden sm:table-cell px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            {{ audience.clients_count }}
           </td>
         </tr>
       </template>


### PR DESCRIPTION
## Summary
- Add **Registration mode** column with color-coded tags derived from `sign_up_enabled` and `invitation_enabled` flags (open, open + invitations, invitation-only, closed)
- Add **Clients count** column showing the number of clients per audience
- Remove **Token Audience** column (to be moved to a future detail page)
- Both new columns are hidden on mobile for a clean responsive layout

Closes #61
Depends on: sympauthy/sympauthy#235

## Test plan
- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes
- [ ] Desktop: 3 columns visible (Audience ID, Registration mode tag, Clients count)
- [ ] Mobile: only Audience ID column visible
- [ ] Tags show correct colors: green (open / open + invitations), yellow (invitation-only), red (closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)